### PR TITLE
Update "meta" job to skip "Sources" if `sources.json` is already up-to-date

### DIFF
--- a/Jenkinsfile.update
+++ b/Jenkinsfile.update
@@ -48,7 +48,27 @@ node {
 				sh 'bashbrew --library .doi/library fetch $(cat subset.txt)' // TODO --all
 			}
 			stage('Sources') {
-				sh '.scripts/sources.sh $(cat subset.txt) > sources.json'
+				sh '''
+					# we only need to regenerate "sources.json" if ".doi", ".scripts", or "subset.txt" have changed since we last generated it
+					needsUpdate=
+					if ! git diff --exit-code .doi .scripts; then
+						# if .doi or .scripts updated in this job ("git submodule update" above)
+						needsUpdate=1
+					else
+						# if subset.txt, .doi, or .scripts updated outside this job (merged PR, etc)
+						sourcesCommit="$(git log -1 --format='format:%H' -- sources.json)"
+						for f in subset.txt .doi .scripts; do
+							commit="$(git log -1 --format='format:%H' -- "$f")"
+							if ! git merge-base --is-ancestor "$commit" "$sourcesCommit"; then
+								needsUpdate=1
+								break
+							fi
+						done
+					fi
+					if [ -n "$needsUpdate" ]; then
+						.scripts/sources.sh $(cat subset.txt) > sources.json
+					fi
+				'''
 			}
 			stage('Builds') {
 				sh '.scripts/builds.sh sources.json > builds.json'
@@ -56,8 +76,11 @@ node {
 		}
 		stage('Commit') {
 			sh '''
-				git add -A .
-				git commit -m 'Update and regenerate' || :
+				# only commit submodule updates if our JSON has changed (see https://github.com/docker-library/meta-scripts/pull/8)
+				if ! git diff --exit-code sources.json builds.json; then
+					git add -A .
+					git commit -m 'Update and regenerate'
+				fi
 			'''
 		}
 		sshagent(['docker-library-bot']) {


### PR DESCRIPTION
The contents of `sources.json` should be really static unless something in the scripts or the upstream sources has changed, so we only need to pay that multi-minute cost in cases where the scripts or source data has actually changed.

There are possibly edge cases here where these upstream things have changed and `sources.json` hasn't/won't. :thinking:

However, this _is_ strictly better than the current state where we just run it all the time.

I think we could probably avoid some of the other edge cases by having this whole script _only_ commit updates to our `.doi` and `.scripts` submodules if `sources.json` or `builds.json` actually have changes. :thinking: