### PR TITLE
Implement `commits.json` that tracks whether `sources.json` is potentially outdated

### DIFF
--- a/Jenkinsfile.update
+++ b/Jenkinsfile.update
@@ -50,23 +50,25 @@ node {
 			stage('Sources') {
 				sh '''
 					# we only need to regenerate "sources.json" if ".doi", ".scripts", or "subset.txt" have changed since we last generated it
-					needsUpdate=
-					if ! git diff --exit-code .doi .scripts; then
-						# if .doi or .scripts updated in this job ("git submodule update" above)
-						needsUpdate=1
-					else
-						# if subset.txt, .doi, or .scripts updated outside this job (merged PR, etc)
-						sourcesCommit="$(git log -1 --format='format:%H' -- sources.json)"
-						for f in subset.txt .doi .scripts; do
-							commit="$(git log -1 --format='format:%H' -- "$f")"
-							if ! git merge-base --is-ancestor "$commit" "$sourcesCommit"; then
-								needsUpdate=1
-								break
-							fi
-						done
+
+					needsBuild=
+					if [ ! -s commits.json ] || [ ! -s sources.json ]; then
+						needsBuild=1
 					fi
-					if [ -n "$needsUpdate" ]; then
-						.scripts/sources.sh $(cat subset.txt) > sources.json
+
+					doi="$(git -C .doi log -1 --format='format:%H')"
+					scripts="$(git -C .scripts log -1 --format='format:%H')"
+					subset="$(sha256sum subset.txt | cut -d' ' -f1)"
+					export doi scripts subset
+					jq -n '{ doi: env.doi, scripts: env.scripts, subset: env.subset }' | tee commits.json
+					if [ -z "$needsBuild" ] && ! git diff --exit-code commits.json; then
+						needsBuild=1
+					fi
+
+					if [ -n "$needsBuild" ]; then
+						images="$(cat subset.txt)"
+						[ -n "$images" ]
+						.scripts/sources.sh $images > sources.json
 					fi
 				'''
 			}
@@ -76,9 +78,8 @@ node {
 		}
 		stage('Commit') {
 			sh '''
-				# only commit submodule updates if our JSON has changed (see https://github.com/docker-library/meta-scripts/pull/8)
-				if ! git diff --exit-code sources.json builds.json; then
-					git add -A .
+				git add -A .
+				if ! git diff --staged --exit-code; then # commit fails if there's nothing to commit
 					git commit -m 'Update and regenerate'
 				fi
 			'''


### PR DESCRIPTION
https://github.com/docker-library/meta-scripts/pull/8#issuecomment-1856298144

> A simpler option would be record in another file which commit of `.doi` and `.scripts` generated the committed `sources.json` so that if there's a new commit that results in no changes to `sources.json`, we still _try_ generating it at least once, but then record that we did so such that we do not have to do so again.  (In case the follow-up question to this is why not just use the submodule commits as this reference, I'm worried that updating submodule commits is something that's too easy to do accidentally, so I'd rather it be something explicitly generated and committed so it's a more clear signal of intent / state.)