### PR TITLE
Fix `nginx` ordering bug

### DIFF
--- a/sources.sh
+++ b/sources.sh
@@ -57,7 +57,7 @@ _sha256() {
 
 json="$(
 	bashbrew cat --build-order --format '
-		{{- range $e := .Entries -}}
+		{{- range $e := .SortedEntries false -}}
 			{{- range $a := $e.Architectures -}}
 				{{- $archNs := archNamespace $a -}}
 				{{- with $e -}}


### PR DESCRIPTION
The `nginx` repo is unique in that the entries in it are not listed in build order -- we were applying `--build-order` to `bashbrew cat`, but that only applies to the repo order, not the `.Entries` order, so we have to use `.SortedEntries` instead which fixes the `panic: parent of d435e69ccd25bbbc51ea5eca965370bb0092d31223261f568b7fc18ac0e0b5a9 on amd64 should be 0887a9d439c66540fbbeb4370141392fb1d2372c2fd3b8d75383f51585001bc6 but that sourceId is unknown to us!` that we see otherwise:

```console
$ diff -u <(bashbrew list --uniq nginx) <(bashbrew list --uniq --build-order nginx)
--- /dev/fd/63	2023-12-20 10:57:23.104310185 -0800
+++ /dev/fd/62	2023-12-20 10:57:23.104310185 -0800
@@ -1,10 +1,10 @@
 nginx:1.25.3
 nginx:1.25.3-perl
-nginx:1.25.3-alpine
-nginx:1.25.3-alpine-perl
 nginx:1.25.3-alpine-slim
 nginx:1.24.0
 nginx:1.24.0-perl
+nginx:1.24.0-alpine-slim
+nginx:1.25.3-alpine
+nginx:1.25.3-alpine-perl
 nginx:1.24.0-alpine
 nginx:1.24.0-alpine-perl
-nginx:1.24.0-alpine-slim
```