### PR TITLE
Set `org.opencontainers.image.base.name` (and `org.opencontainers.image.base.digest`) appropriately

### DIFF
--- a/.test/builds.json
+++ b/.test/builds.json
@@ -93,6 +93,7 @@
           "froms": [
             "alpine:3.18"
           ],
+          "lastStageFrom": "alpine:3.18",
           "platformString": "linux/amd64",
           "platform": {
             "architecture": "amd64",
@@ -190,6 +191,7 @@
           "froms": [
             "alpine:3.18"
           ],
+          "lastStageFrom": "alpine:3.18",
           "platformString": "linux/arm/v6",
           "platform": {
             "architecture": "arm",
@@ -302,6 +304,7 @@
           "froms": [
             "alpine:3.18"
           ],
+          "lastStageFrom": "alpine:3.18",
           "platformString": "linux/arm/v7",
           "platform": {
             "architecture": "arm",
@@ -414,6 +417,7 @@
           "froms": [
             "alpine:3.18"
           ],
+          "lastStageFrom": "alpine:3.18",
           "platformString": "linux/arm64/v8",
           "platform": {
             "architecture": "arm64",
@@ -540,6 +544,7 @@
           "froms": [
             "docker:24-cli"
           ],
+          "lastStageFrom": "docker:24-cli",
           "platformString": "linux/amd64",
           "platform": {
             "architecture": "amd64",
@@ -639,6 +644,7 @@
           "froms": [
             "docker:24-cli"
           ],
+          "lastStageFrom": "docker:24-cli",
           "platformString": "linux/arm/v6",
           "platform": {
             "architecture": "arm",
@@ -767,6 +773,7 @@
           "froms": [
             "docker:24-cli"
           ],
+          "lastStageFrom": "docker:24-cli",
           "platformString": "linux/arm/v7",
           "platform": {
             "architecture": "arm",
@@ -895,6 +902,7 @@
           "froms": [
             "docker:24-cli"
           ],
+          "lastStageFrom": "docker:24-cli",
           "platformString": "linux/arm64/v8",
           "platform": {
             "architecture": "arm64",
@@ -1002,6 +1010,7 @@
           "froms": [
             "mcr.microsoft.com/windows/servercore:ltsc2022"
           ],
+          "lastStageFrom": "mcr.microsoft.com/windows/servercore:ltsc2022",
           "platformString": "windows/amd64",
           "platform": {
             "architecture": "amd64",
@@ -1108,6 +1117,7 @@
           "froms": [
             "mcr.microsoft.com/windows/servercore:1809"
           ],
+          "lastStageFrom": "mcr.microsoft.com/windows/servercore:1809",
           "platformString": "windows/amd64",
           "platform": {
             "architecture": "amd64",
@@ -1236,6 +1246,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/amd64",
           "platform": {
             "architecture": "amd64",
@@ -1357,6 +1368,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/arm/v6",
           "platform": {
             "architecture": "arm",
@@ -1493,6 +1505,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/arm64/v8",
           "platform": {
             "architecture": "arm64",
@@ -1626,6 +1639,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/386",
           "platform": {
             "architecture": "386",
@@ -1758,6 +1772,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/ppc64le",
           "platform": {
             "architecture": "ppc64le",
@@ -1890,6 +1905,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/s390x",
           "platform": {
             "architecture": "s390x",
@@ -2022,6 +2038,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/amd64",
           "platform": {
             "architecture": "amd64",
@@ -2143,6 +2160,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/arm/v6",
           "platform": {
             "architecture": "arm",
@@ -2279,6 +2297,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/arm64/v8",
           "platform": {
             "architecture": "arm64",
@@ -2412,6 +2431,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/386",
           "platform": {
             "architecture": "386",
@@ -2544,6 +2564,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/ppc64le",
           "platform": {
             "architecture": "ppc64le",
@@ -2676,6 +2697,7 @@
             "alpine:3.16",
             "golang:1.19-alpine3.16"
           ],
+          "lastStageFrom": "alpine:3.16",
           "platformString": "linux/s390x",
           "platform": {
             "architecture": "s390x",

--- a/.test/example-commands.sh
+++ b/.test/example-commands.sh
@@ -13,11 +13,15 @@ SOURCE_DATE_EPOCH=1700741054 \
 	--annotation 'org.opencontainers.image.created=2023-11-23T12:04:14Z' \
 	--annotation 'org.opencontainers.image.version=24.0.7-cli' \
 	--annotation 'org.opencontainers.image.url=https://hub.docker.com/_/docker' \
+	--annotation 'org.opencontainers.image.base.name=alpine:3.18' \
+	--annotation 'org.opencontainers.image.base.digest=sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389' \
 	--annotation 'manifest-descriptor:org.opencontainers.image.source=https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli' \
 	--annotation 'manifest-descriptor:org.opencontainers.image.revision=6d541d27b5dd12639e5a33a675ebca04d3837d74' \
 	--annotation 'manifest-descriptor:org.opencontainers.image.created=1970-01-01T00:00:00Z' \
 	--annotation 'manifest-descriptor:org.opencontainers.image.version=24.0.7-cli' \
 	--annotation 'manifest-descriptor:org.opencontainers.image.url=https://hub.docker.com/_/docker' \
+	--annotation 'manifest-descriptor:org.opencontainers.image.base.name=alpine:3.18' \
+	--annotation 'manifest-descriptor:org.opencontainers.image.base.digest=sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389' \
 	--tag 'docker:24.0.7-cli' \
 	--tag 'docker:24.0-cli' \
 	--tag 'docker:24-cli' \

--- a/.test/sources.json
+++ b/.test/sources.json
@@ -31,6 +31,7 @@
         "froms": [
           "alpine:3.18"
         ],
+        "lastStageFrom": "alpine:3.18",
         "platformString": "linux/amd64",
         "platform": {
           "architecture": "amd64",
@@ -55,6 +56,7 @@
         "froms": [
           "alpine:3.18"
         ],
+        "lastStageFrom": "alpine:3.18",
         "platformString": "linux/arm/v6",
         "platform": {
           "architecture": "arm",
@@ -80,6 +82,7 @@
         "froms": [
           "alpine:3.18"
         ],
+        "lastStageFrom": "alpine:3.18",
         "platformString": "linux/arm/v7",
         "platform": {
           "architecture": "arm",
@@ -105,6 +108,7 @@
         "froms": [
           "alpine:3.18"
         ],
+        "lastStageFrom": "alpine:3.18",
         "platformString": "linux/arm64/v8",
         "platform": {
           "architecture": "arm64",
@@ -162,6 +166,7 @@
         "froms": [
           "docker:24-cli"
         ],
+        "lastStageFrom": "docker:24-cli",
         "platformString": "linux/amd64",
         "platform": {
           "architecture": "amd64",
@@ -191,6 +196,7 @@
         "froms": [
           "docker:24-cli"
         ],
+        "lastStageFrom": "docker:24-cli",
         "platformString": "linux/arm/v6",
         "platform": {
           "architecture": "arm",
@@ -221,6 +227,7 @@
         "froms": [
           "docker:24-cli"
         ],
+        "lastStageFrom": "docker:24-cli",
         "platformString": "linux/arm/v7",
         "platform": {
           "architecture": "arm",
@@ -251,6 +258,7 @@
         "froms": [
           "docker:24-cli"
         ],
+        "lastStageFrom": "docker:24-cli",
         "platformString": "linux/arm64/v8",
         "platform": {
           "architecture": "arm64",
@@ -304,6 +312,7 @@
         "froms": [
           "mcr.microsoft.com/windows/servercore:ltsc2022"
         ],
+        "lastStageFrom": "mcr.microsoft.com/windows/servercore:ltsc2022",
         "platformString": "windows/amd64",
         "platform": {
           "architecture": "amd64",
@@ -356,6 +365,7 @@
         "froms": [
           "mcr.microsoft.com/windows/servercore:1809"
         ],
+        "lastStageFrom": "mcr.microsoft.com/windows/servercore:1809",
         "platformString": "windows/amd64",
         "platform": {
           "architecture": "amd64",
@@ -398,6 +408,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/amd64",
         "platform": {
           "architecture": "amd64",
@@ -425,6 +436,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/arm/v6",
         "platform": {
           "architecture": "arm",
@@ -453,6 +465,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/arm64/v8",
         "platform": {
           "architecture": "arm64",
@@ -481,6 +494,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/386",
         "platform": {
           "architecture": "386",
@@ -508,6 +522,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/ppc64le",
         "platform": {
           "architecture": "ppc64le",
@@ -535,6 +550,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/s390x",
         "platform": {
           "architecture": "s390x",
@@ -581,6 +597,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/amd64",
         "platform": {
           "architecture": "amd64",
@@ -608,6 +625,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/arm/v6",
         "platform": {
           "architecture": "arm",
@@ -636,6 +654,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/arm64/v8",
         "platform": {
           "architecture": "arm64",
@@ -664,6 +683,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/386",
         "platform": {
           "architecture": "386",
@@ -691,6 +711,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/ppc64le",
         "platform": {
           "architecture": "ppc64le",
@@ -718,6 +739,7 @@
           "alpine:3.16",
           "golang:1.19-alpine3.16"
         ],
+        "lastStageFrom": "alpine:3.16",
         "platformString": "linux/s390x",
         "platform": {
           "architecture": "s390x",

--- a/sources.sh
+++ b/sources.sh
@@ -65,6 +65,7 @@ bashbrew cat --build-order --format '
 							"tags": {{ $.Tags namespace false . | json }},
 							"archTags": {{ if $archNs -}} {{ $.Tags $archNs false . | json }} {{- else -}} [] {{- end }},
 							"froms": {{ $.ArchDockerFroms $a . | json }},
+							"lastStageFrom": {{ $.ArchLastStageFrom $a . | json }},
 							"platformString": {{ (ociPlatform $a).String | json }},
 							"platform": {{ ociPlatform $a | json }},
 							"parents": { }


### PR DESCRIPTION
See https://github.com/opencontainers/image-spec/blob/v1.1.0-rc6/annotations.md#pre-defined-annotation-keys

See also https://github.com/opencontainers/image-spec/issues/821 and https://github.com/opencontainers/image-spec/pull/822

I noticed recently again that I'd implemented `ArchLastStageFrom` (which is what's necessary to set these correctly), _and_ thanks to #18 and #17, this implementation's correctness is easier to have confidence in. :smile: