### PR TITLE
Add `linguist-language` git attribute for GitHub's sake

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Jenkinsfile*  linguist-language=groovy


### PR DESCRIPTION
Otherwise, our `Jenkinsfile`s are rendered badly.