### PR TITLE
Move Launchpad references to my temp GitHub for now

### DIFF
--- a/.test/builds.json
+++ b/.test/builds.json
@@ -2737,7 +2737,7 @@
         "ubuntu:latest"
       ],
       "entry": {
-        "GitRepo": "https://git.launchpad.net/cloud-images/+oci/ubuntu-base",
+        "GitRepo": "https://github.com/tianon/temp.git",
         "GitFetch": "refs/tags/dist-jammy-amd64-20240111-e6e3490a",
         "GitCommit": "e6e3490ad3f524ccaa072edafe525f8ca8ac5490",
         "Directory": "oci",

--- a/.test/example-commands.sh
+++ b/.test/example-commands.sh
@@ -91,7 +91,7 @@ git init --bare "$gitCache"
 _git() { git -C "$gitCache" "$@"; }
 _git config gc.auto 0
 _commit() { _git rev-parse 'e6e3490ad3f524ccaa072edafe525f8ca8ac5490^{commit}'; }
-if ! _commit &> /dev/null; then _git fetch 'https://git.launchpad.net/cloud-images/+oci/ubuntu-base' 'e6e3490ad3f524ccaa072edafe525f8ca8ac5490:' || _git fetch 'refs/tags/dist-jammy-amd64-20240111-e6e3490a:'; fi
+if ! _commit &> /dev/null; then _git fetch 'https://github.com/tianon/temp.git' 'e6e3490ad3f524ccaa072edafe525f8ca8ac5490:' || _git fetch 'refs/tags/dist-jammy-amd64-20240111-e6e3490a:'; fi
 _commit
 mkdir temp
 _git archive --format=tar 'e6e3490ad3f524ccaa072edafe525f8ca8ac5490:oci/' | tar -xvC temp
@@ -121,7 +121,7 @@ jq -s '
 			error("invalid descriptor size: " + .size)
 		else . end
 		| del(.annotations, .urls)
-		| .annotations = {"org.opencontainers.image.source":"https://git.launchpad.net/cloud-images/+oci/ubuntu-base","org.opencontainers.image.revision":"e6e3490ad3f524ccaa072edafe525f8ca8ac5490","org.opencontainers.image.created":"2024-01-11T00:00:00Z","org.opencontainers.image.version":"22.04","org.opencontainers.image.url":"https://hub.docker.com/_/ubuntu","com.docker.official-images.bashbrew.arch":"amd64","org.opencontainers.image.base.name":"scratch"}
+		| .annotations = {"org.opencontainers.image.source":"https://github.com/tianon/temp.git","org.opencontainers.image.revision":"e6e3490ad3f524ccaa072edafe525f8ca8ac5490","org.opencontainers.image.created":"2024-01-11T00:00:00Z","org.opencontainers.image.version":"22.04","org.opencontainers.image.url":"https://hub.docker.com/_/ubuntu","com.docker.official-images.bashbrew.arch":"amd64","org.opencontainers.image.base.name":"scratch"}
 	)
 ' temp/index.json > temp/index.json.new
 mv temp/index.json.new temp/index.json

--- a/.test/library/ubuntu
+++ b/.test/library/ubuntu
@@ -1,7 +1,9 @@
 # https://github.com/docker-library/official-images/blob/fe9c059402181390eac083cbdd7229b5d123236e/library/ubuntu but intentionally slimmed down (just "latest" on one architecture, no email addresses)
+# ... https://github.com/docker-library/meta-scripts/issues/25 (moved to GitHub because Launchpad won't give us old commits)
 
 Maintainers: Tomáš Virtus (@woky), Cristóvão Cordeiro (@cjdcordeiro)
-GitRepo: https://git.launchpad.net/cloud-images/+oci/ubuntu-base
+#GitRepo: https://git.launchpad.net/cloud-images/+oci/ubuntu-base
+GitRepo: https://github.com/tianon/temp.git
 GitCommit: fa42be9027eccb928a1f0f43d95ffd9a45d36737
 Builder: oci-import
 File: index.json

--- a/.test/sources.json
+++ b/.test/sources.json
@@ -768,7 +768,7 @@
       "ubuntu:latest"
     ],
     "entry": {
-      "GitRepo": "https://git.launchpad.net/cloud-images/+oci/ubuntu-base",
+      "GitRepo": "https://github.com/tianon/temp.git",
       "GitFetch": "refs/tags/dist-jammy-amd64-20240111-e6e3490a",
       "GitCommit": "e6e3490ad3f524ccaa072edafe525f8ca8ac5490",
       "Directory": "oci",


### PR DESCRIPTION
In the future, we'll hopefully get `busybox` converted over to `oci-import` so that this will no longer be necessary and we can delete this whole file instead (in favor of a `busybox` file instead).

Fixes https://github.com/docker-library/meta-scripts/issues/25