### PR TITLE
Fix GHA trigger for Windows images

### DIFF
--- a/Jenkinsfile.trigger
+++ b/Jenkinsfile.trigger
@@ -109,33 +109,8 @@ node {
 								# https://docs.github.com/en/free-pro-team@latest/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
 								payload="$(
 									jq <<<"$json" -L.scripts '
-										include "meta";
-										{
-											ref: "subset", # TODO back to main
-											inputs: (
-												{
-													buildId: .buildId,
-													bashbrewArch: .build.arch,
-													firstTag: .source.tags[0],
-												} + (
-													[ .build.resolvedParents[].manifest.desc.platform? | select(has("os.version")) | ."os.version" ][0] // ""
-													| if . != "" then
-														{ windowsVersion: (
-															# https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
-															# https://github.com/microsoft/hcsshim/blob/e8208853ff0f7f23fa5d2e018deddff2249d35c8/osversion/windowsbuilds.go
-															capture("^10[.]0[.](?<build>[0-9]+)([.]|$)")
-															| {
-																# since this is specifically for GitHub Actions support, this is limited to the underlying versions they actually support
-																# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-																"20348": "2022",
-																"17763": "2019",
-																"": "",
-															}[.build] // "unknown"
-														) }
-													else {} end
-												)
-											)
-										}
+										include "jenkins";
+										gha_payload
 									'
 								)"
 


### PR DESCRIPTION
This fixes the GHA trigger job to account for the data models changes in https://github.com/docker-library/meta-scripts/pull/27. Also moves the jq from the Jenkinsfile to a jq module for easier debugging.

main change:
```diff
-[ .build.resolvedParents[].manifest.desc.platform? | select(has("os.version")) | ."os.version" ][0] // ""
+[ .build.resolvedParents[].manifests[].platform? | select(has("os.version")) | ."os.version" ][0] // ""
```

```console
$ jq -L. 'include "meta";  first( .[] | select( .build.arch == "amd64" ) )' ../meta/builds.json | jq 'include "jenkins"; gha_payload'
{
  "ref": "subset",
  "inputs": {
    "buildId": "7cc7df30afc4b4d52dd16d4b6d1335d9c913ae59b5533350f5debf8c07e4fc31",
    "bashbrewArch": "amd64",
    "firstTag": "bash:devel-20240304"
  }
}
$ jq -L. 'include "meta";  first( .[] | select( needs_build and .build.arch == "windows-amd64" ) )' ../meta/builds.json | jq 'include "jenkins"; gha_payload'
{
  "ref": "subset",
  "inputs": {
    "buildId": "3e083562fa8d67d9a48c3d94a06c65dfd5177c4593334cf1b898d4cbafffc71f",
    "bashbrewArch": "windows-amd64",
    "firstTag": "docker:26.0.0-rc1-windowsservercore-ltsc2022",
    "windowsVersion": "2022"
  }
}
```

Current failure is GHA jobs just failing to start by waiting for a non-existent windows machine:
```
Requested labels: windows-
Job defined at: docker-library/meta/.github/workflows/build.yml@refs/heads/subset
Waiting for a runner to pick up this job...
```