### PR TITLE
Add a `Reference` wrapper type to `ociref.Reference` to handle our "Docker references" logic more cleanly

### DIFF
--- a/.test/builds.json
+++ b/.test/builds.json
@@ -13,7 +13,7 @@
             "size": 2372,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
               "org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
               "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
               "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -30,7 +30,7 @@
             "size": 840,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
               "vnd.docker.reference.digest": "sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -41,7 +41,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
         }
       },
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
@@ -60,7 +60,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "amd64",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389"
+                "org.opencontainers.image.ref.name": "alpine@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389"
               },
               "platform": {
                 "architecture": "amd64",
@@ -69,7 +69,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
+            "org.opencontainers.image.ref.name": "alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
           }
         }
       }
@@ -135,7 +135,7 @@
             "size": 2203,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v6",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
             },
             "platform": {
               "architecture": "arm",
@@ -145,7 +145,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
         }
       },
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
@@ -164,7 +164,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v6",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:1832ef473ede9a923cc6affdf13b54a1be6561ad2ce3c3684910260a7582d36b"
+                "org.opencontainers.image.ref.name": "alpine@sha256:1832ef473ede9a923cc6affdf13b54a1be6561ad2ce3c3684910260a7582d36b"
               },
               "platform": {
                 "architecture": "arm",
@@ -174,7 +174,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
+            "org.opencontainers.image.ref.name": "alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
           }
         }
       }
@@ -241,7 +241,7 @@
             "size": 2372,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v7",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
               "org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
               "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
               "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -259,7 +259,7 @@
             "size": 840,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v7",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
               "vnd.docker.reference.digest": "sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -270,7 +270,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:b6ebc3e33976b79e335395f06a860b09bb9482165ca7869a46f8411957eacf24"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:b6ebc3e33976b79e335395f06a860b09bb9482165ca7869a46f8411957eacf24"
         }
       },
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
@@ -289,7 +289,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v7",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:211fe64069acea47ea680c0943b5a77be1819d0e85365011595391f7562caf27"
+                "org.opencontainers.image.ref.name": "alpine@sha256:211fe64069acea47ea680c0943b5a77be1819d0e85365011595391f7562caf27"
               },
               "platform": {
                 "architecture": "arm",
@@ -299,7 +299,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
+            "org.opencontainers.image.ref.name": "alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
           }
         }
       }
@@ -366,7 +366,7 @@
             "size": 2372,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
               "org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
               "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
               "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -384,7 +384,7 @@
             "size": 840,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
               "vnd.docker.reference.digest": "sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -395,7 +395,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:7f3e5197835a12756f5233447dbab9a5d67ab5e094a939308299a15edf5eefca"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:7f3e5197835a12756f5233447dbab9a5d67ab5e094a939308299a15edf5eefca"
         }
       },
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
@@ -414,7 +414,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm64v8",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:d4ade3639c27579321046d78cc44ec978cea8357d56932611984f601d27e30ac"
+                "org.opencontainers.image.ref.name": "alpine@sha256:d4ade3639c27579321046d78cc44ec978cea8357d56932611984f601d27e30ac"
               },
               "platform": {
                 "architecture": "arm64",
@@ -424,7 +424,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
+            "org.opencontainers.image.ref.name": "alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
           }
         }
       }
@@ -491,7 +491,7 @@
             "size": 3327,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
               "org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
               "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
               "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -508,7 +508,7 @@
             "size": 840,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:bd33f1033e5aa789410574b03beda7415cfc5b7826beba9148d9ca45395029a7",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:bd33f1033e5aa789410574b03beda7415cfc5b7826beba9148d9ca45395029a7",
               "vnd.docker.reference.digest": "sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -519,7 +519,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:b41b0f3fcaf8866e4907a9104ece79aef61328789f3a3b4b9bf92eea5124a728"
+          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:b41b0f3fcaf8866e4907a9104ece79aef61328789f3a3b4b9bf92eea5124a728"
         }
       },
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
@@ -538,7 +538,7 @@
               "size": 2372,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "amd64",
-                "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
+                "org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
                 "org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
                 "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
                 "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -555,7 +555,7 @@
               "size": 840,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "amd64",
-                "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
+                "org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
                 "vnd.docker.reference.digest": "sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
                 "vnd.docker.reference.type": "attestation-manifest"
               },
@@ -566,7 +566,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+            "org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
           }
         }
       }
@@ -642,7 +642,7 @@
             "size": 3251,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v6",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
             },
             "platform": {
               "architecture": "arm",
@@ -652,7 +652,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
         }
       },
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
@@ -671,7 +671,7 @@
               "size": 2203,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v6",
-                "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
+                "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
               },
               "platform": {
                 "architecture": "arm",
@@ -681,7 +681,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
+            "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
           }
         }
       }
@@ -758,7 +758,7 @@
             "size": 3327,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v7",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
               "org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
               "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
               "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -776,7 +776,7 @@
             "size": 840,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v7",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:9b19df42d31ff6d0bad19c17186093b153048b53ef33c7de0c9e76ae9a4412d0",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:9b19df42d31ff6d0bad19c17186093b153048b53ef33c7de0c9e76ae9a4412d0",
               "vnd.docker.reference.digest": "sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -787,7 +787,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:c36ec6ddcbe0e9b0b9a2d957fc0521b01fbeca74d74aea790d3ca7a7dea690a3"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:c36ec6ddcbe0e9b0b9a2d957fc0521b01fbeca74d74aea790d3ca7a7dea690a3"
         }
       },
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
@@ -806,7 +806,7 @@
               "size": 2372,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v7",
-                "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
+                "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
                 "org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
                 "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
                 "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -824,7 +824,7 @@
               "size": 840,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v7",
-                "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
+                "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
                 "vnd.docker.reference.digest": "sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
                 "vnd.docker.reference.type": "attestation-manifest"
               },
@@ -835,7 +835,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:b6ebc3e33976b79e335395f06a860b09bb9482165ca7869a46f8411957eacf24"
+            "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:b6ebc3e33976b79e335395f06a860b09bb9482165ca7869a46f8411957eacf24"
           }
         }
       }
@@ -912,7 +912,7 @@
             "size": 3327,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
               "org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
               "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
               "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -930,7 +930,7 @@
             "size": 840,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:885deeb2bb863dbcf0b80bceb8b5be84de59c6132926911ed0d591fa8232935d",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:885deeb2bb863dbcf0b80bceb8b5be84de59c6132926911ed0d591fa8232935d",
               "vnd.docker.reference.digest": "sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -941,7 +941,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:8cbf87eb14de4783e139d5cc69578f424754a0d7479175997aa30b0b49d436e3"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:8cbf87eb14de4783e139d5cc69578f424754a0d7479175997aa30b0b49d436e3"
         }
       },
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
@@ -960,7 +960,7 @@
               "size": 2372,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm64v8",
-                "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
+                "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
                 "org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
                 "org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
                 "org.opencontainers.image.url": "https://hub.docker.com/_/docker",
@@ -978,7 +978,7 @@
               "size": 840,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm64v8",
-                "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
+                "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
                 "vnd.docker.reference.digest": "sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
                 "vnd.docker.reference.type": "attestation-manifest"
               },
@@ -989,7 +989,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:7f3e5197835a12756f5233447dbab9a5d67ab5e094a939308299a15edf5eefca"
+            "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:7f3e5197835a12756f5233447dbab9a5d67ab5e094a939308299a15edf5eefca"
           }
         }
       }
@@ -1066,7 +1066,7 @@
             "size": 3462,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "windows-amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+              "org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
             },
             "platform": {
               "architecture": "amd64",
@@ -1076,7 +1076,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+          "org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
         }
       },
       "sourceId": "fc50de1b0dedf55655271fc22721b7d94e09a12d0e6ff6b76871ba6b808f5984",
@@ -1180,7 +1180,7 @@
             "size": 3462,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "windows-amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
+              "org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
             },
             "platform": {
               "architecture": "amd64",
@@ -1190,7 +1190,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
+          "org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
         }
       },
       "sourceId": "10083d7e3bfbe4f9bdb3e38e4846b88d0bea1896caca9ef70de6478b3c20fe9a",
@@ -1294,7 +1294,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -1311,7 +1311,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
               "vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -1322,7 +1322,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7"
+          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7"
         }
       },
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
@@ -1342,7 +1342,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "amd64",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:e785cd4ee42f2c1d3845bae90e43b13d82d580843b1666207a9508807500e69f"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:e785cd4ee42f2c1d3845bae90e43b13d82d580843b1666207a9508807500e69f"
               },
               "platform": {
                 "architecture": "amd64",
@@ -1351,7 +1351,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -1364,7 +1364,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "amd64",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:ca452b8ab373e6de9c39d030870a52b8f0d3a9cf998c43183fd114660ae96330"
+                "org.opencontainers.image.ref.name": "alpine@sha256:ca452b8ab373e6de9c39d030870a52b8f0d3a9cf998c43183fd114660ae96330"
               },
               "platform": {
                 "architecture": "amd64",
@@ -1373,7 +1373,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -1439,7 +1439,7 @@
             "size": 1774,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v6",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
             },
             "platform": {
               "architecture": "arm",
@@ -1449,7 +1449,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
         }
       },
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
@@ -1469,7 +1469,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v6",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:172d83c61d65e51e1fe432994122a4f61de1d6535fae0cfbfb71927cc6f8d828"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:172d83c61d65e51e1fe432994122a4f61de1d6535fae0cfbfb71927cc6f8d828"
               },
               "platform": {
                 "architecture": "arm",
@@ -1479,7 +1479,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -1492,7 +1492,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v6",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:50b367e964ca2624aaa480a693df28fdbc240e0c888c13f978e30f4efc2e7ae6"
+                "org.opencontainers.image.ref.name": "alpine@sha256:50b367e964ca2624aaa480a693df28fdbc240e0c888c13f978e30f4efc2e7ae6"
               },
               "platform": {
                 "architecture": "arm",
@@ -1502,7 +1502,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -1569,7 +1569,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -1587,7 +1587,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:c854751d0900f72cc6aaa35d5219de9528cc80a236cac79febb9c6a8bcd451de",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:c854751d0900f72cc6aaa35d5219de9528cc80a236cac79febb9c6a8bcd451de",
               "vnd.docker.reference.digest": "sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -1598,7 +1598,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:8a65a848a3d45898b726849eb47ddaa199e71d3962133f107a45f51fb74fd73a"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:8a65a848a3d45898b726849eb47ddaa199e71d3962133f107a45f51fb74fd73a"
         }
       },
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
@@ -1618,7 +1618,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm64v8",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:9c10ae7a280cab3092646406901f65a60722cf8f6db3a338f4ef471fd884fd84"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:9c10ae7a280cab3092646406901f65a60722cf8f6db3a338f4ef471fd884fd84"
               },
               "platform": {
                 "architecture": "arm64",
@@ -1628,7 +1628,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -1641,7 +1641,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm64v8",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:9796bcac681e439af8e4276c7849dcf38612bff029b3b66e4999d5625b6aef85"
+                "org.opencontainers.image.ref.name": "alpine@sha256:9796bcac681e439af8e4276c7849dcf38612bff029b3b66e4999d5625b6aef85"
               },
               "platform": {
                 "architecture": "arm64",
@@ -1651,7 +1651,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -1718,7 +1718,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "i386",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
+              "org.opencontainers.image.ref.name": "oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -1735,7 +1735,7 @@
             "size": 567,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "i386",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:0b8400d1572fdb0f4c7543b5b66713df78a4c35200f8d147e8d424cc79def783",
+              "org.opencontainers.image.ref.name": "oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:0b8400d1572fdb0f4c7543b5b66713df78a4c35200f8d147e8d424cc79def783",
               "vnd.docker.reference.digest": "sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -1746,7 +1746,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:16f71e74b992a74d7c8e9dff93036f10aaf29f0e44a9ceb5b739d8113e82fcf7"
+          "org.opencontainers.image.ref.name": "oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:16f71e74b992a74d7c8e9dff93036f10aaf29f0e44a9ceb5b739d8113e82fcf7"
         }
       },
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
@@ -1766,7 +1766,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "i386",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:f1de15aa95b3c59b5afbe3ae6feedc5ae5277deb24ef55a7ae2e5863efc43ae9"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:f1de15aa95b3c59b5afbe3ae6feedc5ae5277deb24ef55a7ae2e5863efc43ae9"
               },
               "platform": {
                 "architecture": "386",
@@ -1775,7 +1775,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -1788,7 +1788,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "i386",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:69d5211febf80ceb758b09bed56969ca0b00560f812d58406dd8a31b65942b2b"
+                "org.opencontainers.image.ref.name": "alpine@sha256:69d5211febf80ceb758b09bed56969ca0b00560f812d58406dd8a31b65942b2b"
               },
               "platform": {
                 "architecture": "386",
@@ -1797,7 +1797,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -1863,7 +1863,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "ppc64le",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
+              "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -1880,7 +1880,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "ppc64le",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:6235a23c8e809f36b0e6a6ef45efe0079f9a92ddb62d4ac397241074b79d42c7",
+              "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:6235a23c8e809f36b0e6a6ef45efe0079f9a92ddb62d4ac397241074b79d42c7",
               "vnd.docker.reference.digest": "sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -1891,7 +1891,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:f4e1aff8b7e19c3842fb78b2be1e65ec9290e7c6783f087c813987b36400587a"
+          "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:f4e1aff8b7e19c3842fb78b2be1e65ec9290e7c6783f087c813987b36400587a"
         }
       },
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
@@ -1911,7 +1911,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "ppc64le",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:fc3b552857d80ad5c7b22763dc77a8c9ca74b4b22dcf7ce13fc87c9d5f613248"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:fc3b552857d80ad5c7b22763dc77a8c9ca74b4b22dcf7ce13fc87c9d5f613248"
               },
               "platform": {
                 "architecture": "ppc64le",
@@ -1920,7 +1920,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -1933,7 +1933,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "ppc64le",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:b1da5b7282cab6b45d04b6da5185060bb7e17b3b70a48994c87f2c4cc97141ff"
+                "org.opencontainers.image.ref.name": "alpine@sha256:b1da5b7282cab6b45d04b6da5185060bb7e17b3b70a48994c87f2c4cc97141ff"
               },
               "platform": {
                 "architecture": "ppc64le",
@@ -1942,7 +1942,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -2008,7 +2008,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "s390x",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
+              "org.opencontainers.image.ref.name": "oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -2025,7 +2025,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "s390x",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:c35c2d748647d9150a218c6f9bba1ba76b2857c71608e21de4dea7e277400a5f",
+              "org.opencontainers.image.ref.name": "oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:c35c2d748647d9150a218c6f9bba1ba76b2857c71608e21de4dea7e277400a5f",
               "vnd.docker.reference.digest": "sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -2036,7 +2036,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:8b50da43831c731e8504c0b11dfb1573b3096428c780539b77db32ae76653199"
+          "org.opencontainers.image.ref.name": "oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:8b50da43831c731e8504c0b11dfb1573b3096428c780539b77db32ae76653199"
         }
       },
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
@@ -2056,7 +2056,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "s390x",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:b6e5dbb93caec9210c116a2b8f0ca160152c319112f34a06f53ea393805261e3"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:b6e5dbb93caec9210c116a2b8f0ca160152c319112f34a06f53ea393805261e3"
               },
               "platform": {
                 "architecture": "s390x",
@@ -2065,7 +2065,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -2078,7 +2078,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "s390x",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:4fac498c31f00cb2289eae7cca6cfbefb923927d9b0fa9209aec4731c8bf1ea5"
+                "org.opencontainers.image.ref.name": "alpine@sha256:4fac498c31f00cb2289eae7cca6cfbefb923927d9b0fa9209aec4731c8bf1ea5"
               },
               "platform": {
                 "architecture": "s390x",
@@ -2087,7 +2087,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -2153,7 +2153,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -2170,7 +2170,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "amd64",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:9346c6fe8bf3d29a34e0e1d10f1730feff4461a2e4e2cec704a90490be890d77",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:9346c6fe8bf3d29a34e0e1d10f1730feff4461a2e4e2cec704a90490be890d77",
               "vnd.docker.reference.digest": "sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -2181,7 +2181,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:0c0a250eb8a93d1d576e112f03c43c475748df50c007685863c5bf04d45ca3f3"
+          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:0c0a250eb8a93d1d576e112f03c43c475748df50c007685863c5bf04d45ca3f3"
         }
       },
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
@@ -2201,7 +2201,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "amd64",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:e785cd4ee42f2c1d3845bae90e43b13d82d580843b1666207a9508807500e69f"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:e785cd4ee42f2c1d3845bae90e43b13d82d580843b1666207a9508807500e69f"
               },
               "platform": {
                 "architecture": "amd64",
@@ -2210,7 +2210,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -2223,7 +2223,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "amd64",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:ca452b8ab373e6de9c39d030870a52b8f0d3a9cf998c43183fd114660ae96330"
+                "org.opencontainers.image.ref.name": "alpine@sha256:ca452b8ab373e6de9c39d030870a52b8f0d3a9cf998c43183fd114660ae96330"
               },
               "platform": {
                 "architecture": "amd64",
@@ -2232,7 +2232,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -2298,7 +2298,7 @@
             "size": 1774,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm32v6",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
             },
             "platform": {
               "architecture": "arm",
@@ -2308,7 +2308,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
         }
       },
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
@@ -2328,7 +2328,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v6",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:172d83c61d65e51e1fe432994122a4f61de1d6535fae0cfbfb71927cc6f8d828"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:172d83c61d65e51e1fe432994122a4f61de1d6535fae0cfbfb71927cc6f8d828"
               },
               "platform": {
                 "architecture": "arm",
@@ -2338,7 +2338,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -2351,7 +2351,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm32v6",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:50b367e964ca2624aaa480a693df28fdbc240e0c888c13f978e30f4efc2e7ae6"
+                "org.opencontainers.image.ref.name": "alpine@sha256:50b367e964ca2624aaa480a693df28fdbc240e0c888c13f978e30f4efc2e7ae6"
               },
               "platform": {
                 "architecture": "arm",
@@ -2361,7 +2361,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -2428,7 +2428,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -2446,7 +2446,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "arm64v8",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:f5c7a9cc6bd851167a5b945b9057ded69c1ad64e0ce9416663550867a64c5756",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:f5c7a9cc6bd851167a5b945b9057ded69c1ad64e0ce9416663550867a64c5756",
               "vnd.docker.reference.digest": "sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -2457,7 +2457,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:29e6cf08f34de4d30d19bcb21000596af6c215da8fbba5d04ae3d98b0bb665eb"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:29e6cf08f34de4d30d19bcb21000596af6c215da8fbba5d04ae3d98b0bb665eb"
         }
       },
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
@@ -2477,7 +2477,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm64v8",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:9c10ae7a280cab3092646406901f65a60722cf8f6db3a338f4ef471fd884fd84"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:9c10ae7a280cab3092646406901f65a60722cf8f6db3a338f4ef471fd884fd84"
               },
               "platform": {
                 "architecture": "arm64",
@@ -2487,7 +2487,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -2500,7 +2500,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "arm64v8",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:9796bcac681e439af8e4276c7849dcf38612bff029b3b66e4999d5625b6aef85"
+                "org.opencontainers.image.ref.name": "alpine@sha256:9796bcac681e439af8e4276c7849dcf38612bff029b3b66e4999d5625b6aef85"
               },
               "platform": {
                 "architecture": "arm64",
@@ -2510,7 +2510,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -2577,7 +2577,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "i386",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
+              "org.opencontainers.image.ref.name": "oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -2594,7 +2594,7 @@
             "size": 567,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "i386",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:35cff7b9737739368b4f6b47a2dc15f00f3d42ce52226c5298097ded29bf1a44",
+              "org.opencontainers.image.ref.name": "oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:35cff7b9737739368b4f6b47a2dc15f00f3d42ce52226c5298097ded29bf1a44",
               "vnd.docker.reference.digest": "sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -2605,7 +2605,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:e56f38e952dd40f4f3e5d6f970e8868239e199efba77c43c8ad5f387f24de2fa"
+          "org.opencontainers.image.ref.name": "oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:e56f38e952dd40f4f3e5d6f970e8868239e199efba77c43c8ad5f387f24de2fa"
         }
       },
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
@@ -2625,7 +2625,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "i386",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:f1de15aa95b3c59b5afbe3ae6feedc5ae5277deb24ef55a7ae2e5863efc43ae9"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:f1de15aa95b3c59b5afbe3ae6feedc5ae5277deb24ef55a7ae2e5863efc43ae9"
               },
               "platform": {
                 "architecture": "386",
@@ -2634,7 +2634,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -2647,7 +2647,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "i386",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:69d5211febf80ceb758b09bed56969ca0b00560f812d58406dd8a31b65942b2b"
+                "org.opencontainers.image.ref.name": "alpine@sha256:69d5211febf80ceb758b09bed56969ca0b00560f812d58406dd8a31b65942b2b"
               },
               "platform": {
                 "architecture": "386",
@@ -2656,7 +2656,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -2722,7 +2722,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "ppc64le",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
+              "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -2739,7 +2739,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "ppc64le",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:d777a1b17cf821e4518af7210ec644a565bb09521fc8fed18cbb00b146457adc",
+              "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:d777a1b17cf821e4518af7210ec644a565bb09521fc8fed18cbb00b146457adc",
               "vnd.docker.reference.digest": "sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -2750,7 +2750,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:63b53ff8f8a08587f2dfe1f9dfbfd3bb3dc1e99ccf00cdf4c7c879ff947d50b3"
+          "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:63b53ff8f8a08587f2dfe1f9dfbfd3bb3dc1e99ccf00cdf4c7c879ff947d50b3"
         }
       },
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
@@ -2770,7 +2770,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "ppc64le",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:fc3b552857d80ad5c7b22763dc77a8c9ca74b4b22dcf7ce13fc87c9d5f613248"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:fc3b552857d80ad5c7b22763dc77a8c9ca74b4b22dcf7ce13fc87c9d5f613248"
               },
               "platform": {
                 "architecture": "ppc64le",
@@ -2779,7 +2779,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -2792,7 +2792,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "ppc64le",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:b1da5b7282cab6b45d04b6da5185060bb7e17b3b70a48994c87f2c4cc97141ff"
+                "org.opencontainers.image.ref.name": "alpine@sha256:b1da5b7282cab6b45d04b6da5185060bb7e17b3b70a48994c87f2c4cc97141ff"
               },
               "platform": {
                 "architecture": "ppc64le",
@@ -2801,7 +2801,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -2867,7 +2867,7 @@
             "size": 1998,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "s390x",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
+              "org.opencontainers.image.ref.name": "oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
               "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
               "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
               "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
@@ -2884,7 +2884,7 @@
             "size": 839,
             "annotations": {
               "com.docker.official-images.bashbrew.arch": "s390x",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:c84dbdb9b42aafc6e1def960ec053709e57577b1eb06ea6cdb66da0e94acc640",
+              "org.opencontainers.image.ref.name": "oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:c84dbdb9b42aafc6e1def960ec053709e57577b1eb06ea6cdb66da0e94acc640",
               "vnd.docker.reference.digest": "sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
               "vnd.docker.reference.type": "attestation-manifest"
             },
@@ -2895,7 +2895,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:562fb5f01ca7174dc55991dbfab646c5c742a2079f5792762700b25fef76bfbd"
+          "org.opencontainers.image.ref.name": "oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:562fb5f01ca7174dc55991dbfab646c5c742a2079f5792762700b25fef76bfbd"
         }
       },
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
@@ -2915,7 +2915,7 @@
               "size": 1158,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "s390x",
-                "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:b6e5dbb93caec9210c116a2b8f0ca160152c319112f34a06f53ea393805261e3"
+                "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:b6e5dbb93caec9210c116a2b8f0ca160152c319112f34a06f53ea393805261e3"
               },
               "platform": {
                 "architecture": "s390x",
@@ -2924,7 +2924,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
+            "org.opencontainers.image.ref.name": "golang:1.19-alpine3.16@sha256:7d7cc4682f31c69ac36c34cdbd2a5d1963c7c007ed423b7b58b73613ae085e39"
           }
         },
         "alpine:3.16": {
@@ -2937,7 +2937,7 @@
               "size": 528,
               "annotations": {
                 "com.docker.official-images.bashbrew.arch": "s390x",
-                "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:4fac498c31f00cb2289eae7cca6cfbefb923927d9b0fa9209aec4731c8bf1ea5"
+                "org.opencontainers.image.ref.name": "alpine@sha256:4fac498c31f00cb2289eae7cca6cfbefb923927d9b0fa9209aec4731c8bf1ea5"
               },
               "platform": {
                 "architecture": "s390x",
@@ -2946,7 +2946,7 @@
             }
           ],
           "annotations": {
-            "org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
+            "org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
           }
         }
       }
@@ -3014,7 +3014,7 @@
               "com.docker.official-images.bashbrew.arch": "amd64",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0",
+              "org.opencontainers.image.ref.name": "oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0",
               "org.opencontainers.image.revision": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3027,7 +3027,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:70a227928672dffb7d24880bad1a705b527fab650f7503c191e48a209c4a0d10"
+          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:70a227928672dffb7d24880bad1a705b527fab650f7503c191e48a209c4a0d10"
         }
       },
       "sourceId": "df39fa95e66c7e19e56af0f9dfb8b79b15a0422a9b44eb0f16274d3f1f8939a2",
@@ -3098,7 +3098,7 @@
               "com.docker.official-images.bashbrew.arch": "arm32v5",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0",
               "org.opencontainers.image.revision": "7044abc7ee26712d998311b402b975124786e0cf",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3112,7 +3112,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:0e0b5e6c86baf66ac1630f714049ae5a27059e9153f126c41e0eb56943b08cb6"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:0e0b5e6c86baf66ac1630f714049ae5a27059e9153f126c41e0eb56943b08cb6"
         }
       },
       "sourceId": "b3980edf950afc2ae7180a73ac06ddc9bcaab81cd114aae7df8392f1f35f892e",
@@ -3184,7 +3184,7 @@
               "com.docker.official-images.bashbrew.arch": "arm32v6",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a",
               "org.opencontainers.image.revision": "c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3198,7 +3198,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:b9dd6aadd78f7a9699ed99aeb2c6b171f692a20b6635e687cd3700aba1d25750"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:b9dd6aadd78f7a9699ed99aeb2c6b171f692a20b6635e687cd3700aba1d25750"
         }
       },
       "sourceId": "421c676ba4e46b3e8aea52d35c8f7abb90ac02f2c21620b163368a5ffd61ca42",
@@ -3270,7 +3270,7 @@
               "com.docker.official-images.bashbrew.arch": "arm32v7",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc",
               "org.opencontainers.image.revision": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3284,7 +3284,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:93eb991bcaa0ab5134a524c341a00618008caaa47dc95144190f4fbe24ac362c"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:93eb991bcaa0ab5134a524c341a00618008caaa47dc95144190f4fbe24ac362c"
         }
       },
       "sourceId": "c994e7d0aa868570e8ee977e2872d1e6ab51c475718e3fa6840a063df3b2d222",
@@ -3356,7 +3356,7 @@
               "com.docker.official-images.bashbrew.arch": "arm64v8",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07",
+              "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07",
               "org.opencontainers.image.revision": "a8344687869ba9f95e140a62a915a30822ff2147",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3370,7 +3370,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:3fb550d6bc615a21063b275a642999df69de1a18d4be25ecb3b9615e55a823c1"
+          "org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:3fb550d6bc615a21063b275a642999df69de1a18d4be25ecb3b9615e55a823c1"
         }
       },
       "sourceId": "6df3b92e1fb8d579399af7a60ab66f16c8af07edef1fd92b19bb0f1e1272bacd",
@@ -3442,7 +3442,7 @@
               "com.docker.official-images.bashbrew.arch": "i386",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9",
+              "org.opencontainers.image.ref.name": "oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9",
               "org.opencontainers.image.revision": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3455,7 +3455,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:27518fc8de1793263dc386111bb80b500ce3b5efd45fdab5283230ae837f00a7"
+          "org.opencontainers.image.ref.name": "oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:27518fc8de1793263dc386111bb80b500ce3b5efd45fdab5283230ae837f00a7"
         }
       },
       "sourceId": "47078b58d39eb8284b41386f288be91f7cb7b0a99e2789cedf10e2a8dffdd524",
@@ -3526,7 +3526,7 @@
               "com.docker.official-images.bashbrew.arch": "mips64le",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8",
+              "org.opencontainers.image.ref.name": "oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8",
               "org.opencontainers.image.revision": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3539,7 +3539,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:cd875943c751833209130bc3737ab5b7d6dd9fadf43093fa965ac04a45567dbc"
+          "org.opencontainers.image.ref.name": "oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:cd875943c751833209130bc3737ab5b7d6dd9fadf43093fa965ac04a45567dbc"
         }
       },
       "sourceId": "8b56ef1cfc9211b77472a7e939aa15422dcc6d87e02772731cbb318f799dbba4",
@@ -3610,7 +3610,7 @@
               "com.docker.official-images.bashbrew.arch": "ppc64le",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89",
+              "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89",
               "org.opencontainers.image.revision": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3623,7 +3623,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:4899d0c4bc83bb2086ba23907bd4eee0f79d590dd037c60fbbea545b6232088e"
+          "org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:4899d0c4bc83bb2086ba23907bd4eee0f79d590dd037c60fbbea545b6232088e"
         }
       },
       "sourceId": "c11a0df72b00371fc02029c12d79cb82dd7f906da3890a64e14cfe47e92e68db",
@@ -3694,7 +3694,7 @@
               "com.docker.official-images.bashbrew.arch": "riscv64",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:f681eed9b2db497321012a47fa83f50edccb5ae789b07dea2e608e81e05f5899",
+              "org.opencontainers.image.ref.name": "oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:f681eed9b2db497321012a47fa83f50edccb5ae789b07dea2e608e81e05f5899",
               "org.opencontainers.image.revision": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3707,7 +3707,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:40d18300f578ca6dd6f7feaccb047555b9348514a7a495be637732f50de54dcc"
+          "org.opencontainers.image.ref.name": "oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:40d18300f578ca6dd6f7feaccb047555b9348514a7a495be637732f50de54dcc"
         }
       },
       "sourceId": "45b99857330b33443792583e07608a201820afa4b04b916b84682af97d16000a",
@@ -3778,7 +3778,7 @@
               "com.docker.official-images.bashbrew.arch": "s390x",
               "org.opencontainers.image.base.name": "scratch",
               "org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-              "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6",
+              "org.opencontainers.image.ref.name": "oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6",
               "org.opencontainers.image.revision": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
               "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
               "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
@@ -3791,7 +3791,7 @@
           }
         ],
         "annotations": {
-          "org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:15ef327d3dec3c4e9510f2ae1f3e737b9c443c566b70a51ef97776debc9bfd9c"
+          "org.opencontainers.image.ref.name": "oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:15ef327d3dec3c4e9510f2ae1f3e737b9c443c566b70a51ef97776debc9bfd9c"
         }
       },
       "sourceId": "84e209ff3d62b1b76bc238e61391935039b8543e2b6777c792ec52df2ebde99b",

--- a/.test/cache-builds.json
+++ b/.test/cache-builds.json
@@ -1,6 +1,6 @@
 {
 	"indexes": {
-		"docker.io/library/alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0": {
+		"alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0": {
 			"schemaVersion": 2,
 			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
 			"manifests": [
@@ -10,7 +10,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389"
+						"org.opencontainers.image.ref.name": "alpine@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389"
 					},
 					"platform": {
 						"architecture": "amd64",
@@ -23,7 +23,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "arm32v6",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:1832ef473ede9a923cc6affdf13b54a1be6561ad2ce3c3684910260a7582d36b"
+						"org.opencontainers.image.ref.name": "alpine@sha256:1832ef473ede9a923cc6affdf13b54a1be6561ad2ce3c3684910260a7582d36b"
 					},
 					"platform": {
 						"architecture": "arm",
@@ -37,7 +37,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "arm32v7",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:211fe64069acea47ea680c0943b5a77be1819d0e85365011595391f7562caf27"
+						"org.opencontainers.image.ref.name": "alpine@sha256:211fe64069acea47ea680c0943b5a77be1819d0e85365011595391f7562caf27"
 					},
 					"platform": {
 						"architecture": "arm",
@@ -51,7 +51,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:d4ade3639c27579321046d78cc44ec978cea8357d56932611984f601d27e30ac"
+						"org.opencontainers.image.ref.name": "alpine@sha256:d4ade3639c27579321046d78cc44ec978cea8357d56932611984f601d27e30ac"
 					},
 					"platform": {
 						"architecture": "arm64",
@@ -65,7 +65,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "i386",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:5ece42cd6ca30ec1a4cc5e1e10a260ad4906e1d4588ae0ef486874d72b3857ad"
+						"org.opencontainers.image.ref.name": "alpine@sha256:5ece42cd6ca30ec1a4cc5e1e10a260ad4906e1d4588ae0ef486874d72b3857ad"
 					},
 					"platform": {
 						"architecture": "386",
@@ -78,7 +78,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "ppc64le",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:1698bcd6bf339e1578dfb9f0034dff615e3eec8404517045046ecbeb84ad01d6"
+						"org.opencontainers.image.ref.name": "alpine@sha256:1698bcd6bf339e1578dfb9f0034dff615e3eec8404517045046ecbeb84ad01d6"
 					},
 					"platform": {
 						"architecture": "ppc64le",
@@ -91,7 +91,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "s390x",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:5c63479aeed37522de78284d99dcd32f9ad288b04a56236f44e78b3b3f62ebd2"
+						"org.opencontainers.image.ref.name": "alpine@sha256:5c63479aeed37522de78284d99dcd32f9ad288b04a56236f44e78b3b3f62ebd2"
 					},
 					"platform": {
 						"architecture": "s390x",
@@ -100,10 +100,10 @@
 				}
 			],
 			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
+				"org.opencontainers.image.ref.name": "alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0"
 			}
 		},
-		"docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b": {
+		"alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b": {
 			"schemaVersion": 2,
 			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
 			"manifests": [
@@ -113,7 +113,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:ca452b8ab373e6de9c39d030870a52b8f0d3a9cf998c43183fd114660ae96330"
+						"org.opencontainers.image.ref.name": "alpine@sha256:ca452b8ab373e6de9c39d030870a52b8f0d3a9cf998c43183fd114660ae96330"
 					},
 					"platform": {
 						"architecture": "amd64",
@@ -126,7 +126,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "arm32v6",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:50b367e964ca2624aaa480a693df28fdbc240e0c888c13f978e30f4efc2e7ae6"
+						"org.opencontainers.image.ref.name": "alpine@sha256:50b367e964ca2624aaa480a693df28fdbc240e0c888c13f978e30f4efc2e7ae6"
 					},
 					"platform": {
 						"architecture": "arm",
@@ -140,7 +140,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "arm32v7",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:b5a8cebd2749e0b4601d6c0f0bbf9734d87a64f80f1c20100070756531925069"
+						"org.opencontainers.image.ref.name": "alpine@sha256:b5a8cebd2749e0b4601d6c0f0bbf9734d87a64f80f1c20100070756531925069"
 					},
 					"platform": {
 						"architecture": "arm",
@@ -154,7 +154,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:9796bcac681e439af8e4276c7849dcf38612bff029b3b66e4999d5625b6aef85"
+						"org.opencontainers.image.ref.name": "alpine@sha256:9796bcac681e439af8e4276c7849dcf38612bff029b3b66e4999d5625b6aef85"
 					},
 					"platform": {
 						"architecture": "arm64",
@@ -168,7 +168,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "i386",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:69d5211febf80ceb758b09bed56969ca0b00560f812d58406dd8a31b65942b2b"
+						"org.opencontainers.image.ref.name": "alpine@sha256:69d5211febf80ceb758b09bed56969ca0b00560f812d58406dd8a31b65942b2b"
 					},
 					"platform": {
 						"architecture": "386",
@@ -181,7 +181,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "ppc64le",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:b1da5b7282cab6b45d04b6da5185060bb7e17b3b70a48994c87f2c4cc97141ff"
+						"org.opencontainers.image.ref.name": "alpine@sha256:b1da5b7282cab6b45d04b6da5185060bb7e17b3b70a48994c87f2c4cc97141ff"
 					},
 					"platform": {
 						"architecture": "ppc64le",
@@ -194,7 +194,7 @@
 					"size": 528,
 					"annotations": {
 						"com.docker.official-images.bashbrew.arch": "s390x",
-						"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:4fac498c31f00cb2289eae7cca6cfbefb923927d9b0fa9209aec4731c8bf1ea5"
+						"org.opencontainers.image.ref.name": "alpine@sha256:4fac498c31f00cb2289eae7cca6cfbefb923927d9b0fa9209aec4731c8bf1ea5"
 					},
 					"platform": {
 						"architecture": "s390x",
@@ -203,1091 +203,7 @@
 				}
 			],
 			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/library/alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
-			}
-		},
-		"docker.io/oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0",
-						"org.opencontainers.image.revision": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "amd64",
-						"os": "linux"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:70a227928672dffb7d24880bad1a705b527fab650f7503c191e48a209c4a0d10"
-			}
-		},
-		"docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
-					"size": 2372,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
-						"org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
-						"org.opencontainers.image.version": "24.0.7-cli"
-					},
-					"platform": {
-						"architecture": "amd64",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
-					"size": 840,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
-						"vnd.docker.reference.digest": "sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
-			}
-		},
-		"docker.io/oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
-					"size": 3327,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
-						"org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
-						"org.opencontainers.image.version": "24.0.7-dind"
-					},
-					"platform": {
-						"architecture": "amd64",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:bd33f1033e5aa789410574b03beda7415cfc5b7826beba9148d9ca45395029a7",
-					"size": 840,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:bd33f1033e5aa789410574b03beda7415cfc5b7826beba9148d9ca45395029a7",
-						"vnd.docker.reference.digest": "sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:b41b0f3fcaf8866e4907a9104ece79aef61328789f3a3b4b9bf92eea5124a728"
-			}
-		},
-		"docker.io/oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "signer-0.7.0"
-					},
-					"platform": {
-						"architecture": "amd64",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:9346c6fe8bf3d29a34e0e1d10f1730feff4461a2e4e2cec704a90490be890d77",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:9346c6fe8bf3d29a34e0e1d10f1730feff4461a2e4e2cec704a90490be890d77",
-						"vnd.docker.reference.digest": "sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:0c0a250eb8a93d1d576e112f03c43c475748df50c007685863c5bf04d45ca3f3"
-			}
-		},
-		"docker.io/oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "server-0.7.0"
-					},
-					"platform": {
-						"architecture": "amd64",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
-						"vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v5",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0",
-						"org.opencontainers.image.revision": "7044abc7ee26712d998311b402b975124786e0cf",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v5"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:0e0b5e6c86baf66ac1630f714049ae5a27059e9153f126c41e0eb56943b08cb6"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-					"digest": "sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981",
-					"size": 2203,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v6",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v6"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-					"digest": "sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38",
-					"size": 3251,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v6",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v6"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a",
-					"size": 608,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v6",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a",
-						"org.opencontainers.image.revision": "c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-musl"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v6"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:b9dd6aadd78f7a9699ed99aeb2c6b171f692a20b6635e687cd3700aba1d25750"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-					"digest": "sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e",
-					"size": 1774,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v6",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v6"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-					"digest": "sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53",
-					"size": 1774,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v6",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v6"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v7",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc",
-						"org.opencontainers.image.revision": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v7"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:93eb991bcaa0ab5134a524c341a00618008caaa47dc95144190f4fbe24ac362c"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
-					"size": 3327,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v7",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
-						"org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
-						"org.opencontainers.image.version": "24.0.7-dind"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v7"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:9b19df42d31ff6d0bad19c17186093b153048b53ef33c7de0c9e76ae9a4412d0",
-					"size": 840,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v7",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:9b19df42d31ff6d0bad19c17186093b153048b53ef33c7de0c9e76ae9a4412d0",
-						"vnd.docker.reference.digest": "sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:c36ec6ddcbe0e9b0b9a2d957fc0521b01fbeca74d74aea790d3ca7a7dea690a3"
-			}
-		},
-		"docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
-					"size": 2372,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v7",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
-						"org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
-						"org.opencontainers.image.version": "24.0.7-cli"
-					},
-					"platform": {
-						"architecture": "arm",
-						"os": "linux",
-						"variant": "v7"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
-					"size": 840,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm32v7",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
-						"vnd.docker.reference.digest": "sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:b6ebc3e33976b79e335395f06a860b09bb9482165ca7869a46f8411957eacf24"
-			}
-		},
-		"docker.io/oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "server-0.7.0"
-					},
-					"platform": {
-						"architecture": "arm64",
-						"os": "linux",
-						"variant": "v8"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:c854751d0900f72cc6aaa35d5219de9528cc80a236cac79febb9c6a8bcd451de",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:c854751d0900f72cc6aaa35d5219de9528cc80a236cac79febb9c6a8bcd451de",
-						"vnd.docker.reference.digest": "sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:8a65a848a3d45898b726849eb47ddaa199e71d3962133f107a45f51fb74fd73a"
-			}
-		},
-		"docker.io/oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07",
-						"org.opencontainers.image.revision": "a8344687869ba9f95e140a62a915a30822ff2147",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "arm64",
-						"os": "linux",
-						"variant": "v8"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:3fb550d6bc615a21063b275a642999df69de1a18d4be25ecb3b9615e55a823c1"
-			}
-		},
-		"docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
-					"size": 2372,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
-						"org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
-						"org.opencontainers.image.version": "24.0.7-cli"
-					},
-					"platform": {
-						"architecture": "arm64",
-						"os": "linux",
-						"variant": "v8"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
-					"size": 840,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
-						"vnd.docker.reference.digest": "sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:7f3e5197835a12756f5233447dbab9a5d67ab5e094a939308299a15edf5eefca"
-			}
-		},
-		"docker.io/oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "signer-0.7.0"
-					},
-					"platform": {
-						"architecture": "arm64",
-						"os": "linux",
-						"variant": "v8"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:f5c7a9cc6bd851167a5b945b9057ded69c1ad64e0ce9416663550867a64c5756",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:f5c7a9cc6bd851167a5b945b9057ded69c1ad64e0ce9416663550867a64c5756",
-						"vnd.docker.reference.digest": "sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:29e6cf08f34de4d30d19bcb21000596af6c215da8fbba5d04ae3d98b0bb665eb"
-			}
-		},
-		"docker.io/oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
-					"size": 3327,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
-						"org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
-						"org.opencontainers.image.version": "24.0.7-dind"
-					},
-					"platform": {
-						"architecture": "arm64",
-						"os": "linux",
-						"variant": "v8"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:885deeb2bb863dbcf0b80bceb8b5be84de59c6132926911ed0d591fa8232935d",
-					"size": 840,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "arm64v8",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:885deeb2bb863dbcf0b80bceb8b5be84de59c6132926911ed0d591fa8232935d",
-						"vnd.docker.reference.digest": "sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:8cbf87eb14de4783e139d5cc69578f424754a0d7479175997aa30b0b49d436e3"
-			}
-		},
-		"docker.io/oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "i386",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "server-0.7.0"
-					},
-					"platform": {
-						"architecture": "386",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:0b8400d1572fdb0f4c7543b5b66713df78a4c35200f8d147e8d424cc79def783",
-					"size": 567,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "i386",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:0b8400d1572fdb0f4c7543b5b66713df78a4c35200f8d147e8d424cc79def783",
-						"vnd.docker.reference.digest": "sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:16f71e74b992a74d7c8e9dff93036f10aaf29f0e44a9ceb5b739d8113e82fcf7"
-			}
-		},
-		"docker.io/oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "i386",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "signer-0.7.0"
-					},
-					"platform": {
-						"architecture": "386",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:35cff7b9737739368b4f6b47a2dc15f00f3d42ce52226c5298097ded29bf1a44",
-					"size": 567,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "i386",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:35cff7b9737739368b4f6b47a2dc15f00f3d42ce52226c5298097ded29bf1a44",
-						"vnd.docker.reference.digest": "sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:e56f38e952dd40f4f3e5d6f970e8868239e199efba77c43c8ad5f387f24de2fa"
-			}
-		},
-		"docker.io/oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "i386",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9",
-						"org.opencontainers.image.revision": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "386",
-						"os": "linux"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:27518fc8de1793263dc386111bb80b500ce3b5efd45fdab5283230ae837f00a7"
-			}
-		},
-		"docker.io/oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "mips64le",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8",
-						"org.opencontainers.image.revision": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "mips64le",
-						"os": "linux"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:cd875943c751833209130bc3737ab5b7d6dd9fadf43093fa965ac04a45567dbc"
-			}
-		},
-		"docker.io/oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "ppc64le",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89",
-						"org.opencontainers.image.revision": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "ppc64le",
-						"os": "linux"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:4899d0c4bc83bb2086ba23907bd4eee0f79d590dd037c60fbbea545b6232088e"
-			}
-		},
-		"docker.io/oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "ppc64le",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "server-0.7.0"
-					},
-					"platform": {
-						"architecture": "ppc64le",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:6235a23c8e809f36b0e6a6ef45efe0079f9a92ddb62d4ac397241074b79d42c7",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "ppc64le",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:6235a23c8e809f36b0e6a6ef45efe0079f9a92ddb62d4ac397241074b79d42c7",
-						"vnd.docker.reference.digest": "sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:f4e1aff8b7e19c3842fb78b2be1e65ec9290e7c6783f087c813987b36400587a"
-			}
-		},
-		"docker.io/oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "ppc64le",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "signer-0.7.0"
-					},
-					"platform": {
-						"architecture": "ppc64le",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:d777a1b17cf821e4518af7210ec644a565bb09521fc8fed18cbb00b146457adc",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "ppc64le",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:d777a1b17cf821e4518af7210ec644a565bb09521fc8fed18cbb00b146457adc",
-						"vnd.docker.reference.digest": "sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:63b53ff8f8a08587f2dfe1f9dfbfd3bb3dc1e99ccf00cdf4c7c879ff947d50b3"
-			}
-		},
-		"docker.io/oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:f681eed9b2db497321012a47fa83f50edccb5ae789b07dea2e608e81e05f5899",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "riscv64",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:f681eed9b2db497321012a47fa83f50edccb5ae789b07dea2e608e81e05f5899",
-						"org.opencontainers.image.revision": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-uclibc"
-					},
-					"platform": {
-						"architecture": "riscv64",
-						"os": "linux"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:40d18300f578ca6dd6f7feaccb047555b9348514a7a495be637732f50de54dcc"
-			}
-		},
-		"docker.io/oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "s390x",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "signer-0.7.0"
-					},
-					"platform": {
-						"architecture": "s390x",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:c84dbdb9b42aafc6e1def960ec053709e57577b1eb06ea6cdb66da0e94acc640",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "s390x",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:c84dbdb9b42aafc6e1def960ec053709e57577b1eb06ea6cdb66da0e94acc640",
-						"vnd.docker.reference.digest": "sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:562fb5f01ca7174dc55991dbfab646c5c742a2079f5792762700b25fef76bfbd"
-			}
-		},
-		"docker.io/oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6",
-					"size": 610,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "s390x",
-						"org.opencontainers.image.base.name": "scratch",
-						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6",
-						"org.opencontainers.image.revision": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
-						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
-						"org.opencontainers.image.version": "1.36.1-glibc"
-					},
-					"platform": {
-						"architecture": "s390x",
-						"os": "linux"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:15ef327d3dec3c4e9510f2ae1f3e737b9c443c566b70a51ef97776debc9bfd9c"
-			}
-		},
-		"docker.io/oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.oci.image.index.v1+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
-					"size": 1998,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "s390x",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
-						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
-						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-						"org.opencontainers.image.version": "server-0.7.0"
-					},
-					"platform": {
-						"architecture": "s390x",
-						"os": "linux"
-					}
-				},
-				{
-					"mediaType": "application/vnd.oci.image.manifest.v1+json",
-					"digest": "sha256:c35c2d748647d9150a218c6f9bba1ba76b2857c71608e21de4dea7e277400a5f",
-					"size": 839,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "s390x",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:c35c2d748647d9150a218c6f9bba1ba76b2857c71608e21de4dea7e277400a5f",
-						"vnd.docker.reference.digest": "sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
-						"vnd.docker.reference.type": "attestation-manifest"
-					},
-					"platform": {
-						"architecture": "unknown",
-						"os": "unknown"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:8b50da43831c731e8504c0b11dfb1573b3096428c780539b77db32ae76653199"
-			}
-		},
-		"docker.io/oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-					"digest": "sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021",
-					"size": 3462,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "windows-amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
-					},
-					"platform": {
-						"architecture": "amd64",
-						"os": "windows",
-						"os.version": "10.0.17763.5122"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
-			}
-		},
-		"docker.io/oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e": {
-			"schemaVersion": 2,
-			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-			"manifests": [
-				{
-					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-					"digest": "sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce",
-					"size": 3462,
-					"annotations": {
-						"com.docker.official-images.bashbrew.arch": "windows-amd64",
-						"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
-					},
-					"platform": {
-						"architecture": "amd64",
-						"os": "windows",
-						"os.version": "10.0.20348.2113"
-					}
-				}
-			],
-			"annotations": {
-				"org.opencontainers.image.ref.name": "docker.io/oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				"org.opencontainers.image.ref.name": "alpine@sha256:e4cdb7d47b06ba0a062ad2a97a7d154967c8f83934594d9f2bd3efa89292996b"
 			}
 		},
 		"mcr.microsoft.com/windows/servercore@sha256:308ef3f8ee3e9c9a1bdec460009c1e6394b329db13eb3149461f8841be5b538a": {
@@ -1340,6 +256,1090 @@
 			],
 			"annotations": {
 				"org.opencontainers.image.ref.name": "mcr.microsoft.com/windows/servercore@sha256:4fe58f25a157ea749c7b770acebfdbd70c3cb2088c446943e90fe89ea059558b"
+			}
+		},
+		"oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0",
+						"org.opencontainers.image.revision": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "amd64",
+						"os": "linux"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:70a227928672dffb7d24880bad1a705b527fab650f7503c191e48a209c4a0d10"
+			}
+		},
+		"oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
+					"size": 2372,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
+						"org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
+						"org.opencontainers.image.version": "24.0.7-cli"
+					},
+					"platform": {
+						"architecture": "amd64",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
+					"size": 840,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:061239943a7c3d3068527dbdac796118a9f0530d0478a48623f1a49d6aeb21e6",
+						"vnd.docker.reference.digest": "sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+			}
+		},
+		"oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
+					"size": 3327,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
+						"org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
+						"org.opencontainers.image.version": "24.0.7-dind"
+					},
+					"platform": {
+						"architecture": "amd64",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:bd33f1033e5aa789410574b03beda7415cfc5b7826beba9148d9ca45395029a7",
+					"size": 840,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:bd33f1033e5aa789410574b03beda7415cfc5b7826beba9148d9ca45395029a7",
+						"vnd.docker.reference.digest": "sha256:4c92bd9328191f76e8eec6592ceb2e248aa7406dfc9505870812cf8ebee9326a",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-amd64:52e3bf2e5ae5606b777f60a7205b338af7ecf70bfebf714e52979dbf9a055621@sha256:b41b0f3fcaf8866e4907a9104ece79aef61328789f3a3b4b9bf92eea5124a728"
+			}
+		},
+		"oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "signer-0.7.0"
+					},
+					"platform": {
+						"architecture": "amd64",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:9346c6fe8bf3d29a34e0e1d10f1730feff4461a2e4e2cec704a90490be890d77",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:9346c6fe8bf3d29a34e0e1d10f1730feff4461a2e4e2cec704a90490be890d77",
+						"vnd.docker.reference.digest": "sha256:a5f3cf14ec1f9dbe64f5038168764468bf8cf36023f8c1d763abd3bcbe2a5952",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-amd64:57c2ee0d050ffb54c7f2b50c57b807cce8a8c478648c2eb6bbdf1604b34dd1b9@sha256:0c0a250eb8a93d1d576e112f03c43c475748df50c007685863c5bf04d45ca3f3"
+			}
+		},
+		"oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "server-0.7.0"
+					},
+					"platform": {
+						"architecture": "amd64",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+						"vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7"
+			}
+		},
+		"oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v5",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0",
+						"org.opencontainers.image.revision": "7044abc7ee26712d998311b402b975124786e0cf",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v5"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v5:6dad189d12c5b50de48dab19c13869fdf25219dc430fc1d4c8a8dcc7bc893e69@sha256:0e0b5e6c86baf66ac1630f714049ae5a27059e9153f126c41e0eb56943b08cb6"
+			}
+		},
+		"oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+					"digest": "sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981",
+					"size": 2203,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v6",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v6"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:2fa4ebddfdbb2318be99958b867533429ec9fbff92c1e3ee53658609e5490a89@sha256:8afe342ba4d38a2924c9853d4fc812cebbfe56ad8509b80f752e04c4d0ec3981"
+			}
+		},
+		"oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+					"digest": "sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38",
+					"size": 3251,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v6",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v6"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:4e98c0f9e21663851c8cf186fb114fd2440f3de0b0a8d52f6154e23730d0ca04@sha256:db900d48c4071b64779ab61dbc65f20a01dfc9955eec6013c575c6df2c178f38"
+			}
+		},
+		"oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a",
+					"size": 608,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v6",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a",
+						"org.opencontainers.image.revision": "c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-musl"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v6"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:788ce2a5f7beff3bbefa14eeb5fdd69e2e0eea9b432f8b5f3c6deb9bbea141e4@sha256:b9dd6aadd78f7a9699ed99aeb2c6b171f692a20b6635e687cd3700aba1d25750"
+			}
+		},
+		"oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+					"digest": "sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e",
+					"size": 1774,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v6",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v6"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:d5ab9c988abb75a0da68a726aefdade29331f16f154bd15d41942f8d3476d3d1@sha256:9f245d4b08cfa9f6934e315f60699db5caacbf638d012c4c6f16dfa10066ae4e"
+			}
+		},
+		"oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+					"digest": "sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53",
+					"size": 1774,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v6",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v6"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v6:fe9c7d0064f7451bf4c72ab5a82845860a0a49af27fb3ffd0a00a1c20eeccc5f@sha256:65861e496c2a89861f24aae1e230413422204f5d85529405e213e137c03ddf53"
+			}
+		},
+		"oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v7",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc",
+						"org.opencontainers.image.revision": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v7"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:4e0edc2836092590f9fbabe96e2c504815359e36a16b84c4fd0724d8919fc816@sha256:93eb991bcaa0ab5134a524c341a00618008caaa47dc95144190f4fbe24ac362c"
+			}
+		},
+		"oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
+					"size": 3327,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v7",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
+						"org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
+						"org.opencontainers.image.version": "24.0.7-dind"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v7"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:9b19df42d31ff6d0bad19c17186093b153048b53ef33c7de0c9e76ae9a4412d0",
+					"size": 840,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v7",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:9b19df42d31ff6d0bad19c17186093b153048b53ef33c7de0c9e76ae9a4412d0",
+						"vnd.docker.reference.digest": "sha256:dff21d22d9a1e8a1d927234ae319bbeb724737a921dc1a843fd218012b96e993",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:c87eaae1c3107315f6579700fcecec376d90c8d76e3fa59d5f3d2a18b81c44ff@sha256:c36ec6ddcbe0e9b0b9a2d957fc0521b01fbeca74d74aea790d3ca7a7dea690a3"
+			}
+		},
+		"oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
+					"size": 2372,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v7",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
+						"org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
+						"org.opencontainers.image.version": "24.0.7-cli"
+					},
+					"platform": {
+						"architecture": "arm",
+						"os": "linux",
+						"variant": "v7"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
+					"size": 840,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm32v7",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:a7d0fac0c3a8f3b752720cb1649fe2f42d8f487dda1f1fe1992500f5a9173073",
+						"vnd.docker.reference.digest": "sha256:8a0f2a979b051d037be8ada354394105ee3dbfe4bad4e5cf101047cdc2da3abf",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm32v7:f21b47c585fce7db3ff4f646bc87f483fecb3c920d6ec5fbf8a2d76a03ef7ae9@sha256:b6ebc3e33976b79e335395f06a860b09bb9482165ca7869a46f8411957eacf24"
+			}
+		},
+		"oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "server-0.7.0"
+					},
+					"platform": {
+						"architecture": "arm64",
+						"os": "linux",
+						"variant": "v8"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:c854751d0900f72cc6aaa35d5219de9528cc80a236cac79febb9c6a8bcd451de",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:c854751d0900f72cc6aaa35d5219de9528cc80a236cac79febb9c6a8bcd451de",
+						"vnd.docker.reference.digest": "sha256:7cb971c2293a1784f771970101a6f7a684bee811b6ebd0cd9587fecf90d7ee8a",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:535b37066c5ad0d2d9684589705db75f5f33494fbae845627bc8d77f636769e3@sha256:8a65a848a3d45898b726849eb47ddaa199e71d3962133f107a45f51fb74fd73a"
+			}
+		},
+		"oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07",
+						"org.opencontainers.image.revision": "a8344687869ba9f95e140a62a915a30822ff2147",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "arm64",
+						"os": "linux",
+						"variant": "v8"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:966a8b87007b77a4076d74b21ec7faf4d67c52d3cda3e9262763ce785a326b7d@sha256:3fb550d6bc615a21063b275a642999df69de1a18d4be25ecb3b9615e55a823c1"
+			}
+		},
+		"oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
+					"size": 2372,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
+						"org.opencontainers.image.revision": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
+						"org.opencontainers.image.version": "24.0.7-cli"
+					},
+					"platform": {
+						"architecture": "arm64",
+						"os": "linux",
+						"variant": "v8"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
+					"size": 840,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:0effa0c52019fb2ed38d7242c78931aebeab58ac3027747be88e499e0cdd3461",
+						"vnd.docker.reference.digest": "sha256:bd9404aaf047e27974c67bac58a4b7c2975235056a67c4959d4565f8e2389b4b",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:bf4deeb14c5a100aed6a596cc974bb4db704d8189d9a09fb433e12644e3274ea@sha256:7f3e5197835a12756f5233447dbab9a5d67ab5e094a939308299a15edf5eefca"
+			}
+		},
+		"oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "signer-0.7.0"
+					},
+					"platform": {
+						"architecture": "arm64",
+						"os": "linux",
+						"variant": "v8"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:f5c7a9cc6bd851167a5b945b9057ded69c1ad64e0ce9416663550867a64c5756",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:f5c7a9cc6bd851167a5b945b9057ded69c1ad64e0ce9416663550867a64c5756",
+						"vnd.docker.reference.digest": "sha256:974493bb14128e55fa9a95615788a430df892ca0dcdba0141c81a543f7597ecb",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:d20c425b32e42806dff6d00acb99a8c95e14b773b978f44587f472aa38336691@sha256:29e6cf08f34de4d30d19bcb21000596af6c215da8fbba5d04ae3d98b0bb665eb"
+			}
+		},
+		"oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
+					"size": 3327,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
+						"org.opencontainers.image.revision": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+						"org.opencontainers.image.source": "https://github.com/docker-library/docker.git#99073a3b6be3aa7e6b5af1e69509e8c532254500:24/dind",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/docker",
+						"org.opencontainers.image.version": "24.0.7-dind"
+					},
+					"platform": {
+						"architecture": "arm64",
+						"os": "linux",
+						"variant": "v8"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:885deeb2bb863dbcf0b80bceb8b5be84de59c6132926911ed0d591fa8232935d",
+					"size": 840,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "arm64v8",
+						"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:885deeb2bb863dbcf0b80bceb8b5be84de59c6132926911ed0d591fa8232935d",
+						"vnd.docker.reference.digest": "sha256:2afeb0c1357ac43eb81976a3a84995645872ab18644f6799677cd786de54cf40",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-arm64v8:e8e572b413236b909b53fe962f2b91a981cfe91514f0f81b251b65e14a06e60a@sha256:8cbf87eb14de4783e139d5cc69578f424754a0d7479175997aa30b0b49d436e3"
+			}
+		},
+		"oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "i386",
+						"org.opencontainers.image.ref.name": "oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "server-0.7.0"
+					},
+					"platform": {
+						"architecture": "386",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:0b8400d1572fdb0f4c7543b5b66713df78a4c35200f8d147e8d424cc79def783",
+					"size": 567,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "i386",
+						"org.opencontainers.image.ref.name": "oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:0b8400d1572fdb0f4c7543b5b66713df78a4c35200f8d147e8d424cc79def783",
+						"vnd.docker.reference.digest": "sha256:e6d16088d6a27939ccbde71947f57ef7db02215049c18b82ccbc58ffc19875ab",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-i386:7d563d914d72c37cc7a59c0ef9d5ede304412f9c5417b72e82d1963c70e8cbfb@sha256:16f71e74b992a74d7c8e9dff93036f10aaf29f0e44a9ceb5b739d8113e82fcf7"
+			}
+		},
+		"oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "i386",
+						"org.opencontainers.image.ref.name": "oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "signer-0.7.0"
+					},
+					"platform": {
+						"architecture": "386",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:35cff7b9737739368b4f6b47a2dc15f00f3d42ce52226c5298097ded29bf1a44",
+					"size": 567,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "i386",
+						"org.opencontainers.image.ref.name": "oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:35cff7b9737739368b4f6b47a2dc15f00f3d42ce52226c5298097ded29bf1a44",
+						"vnd.docker.reference.digest": "sha256:b4dab61b2d4468f7afa31ff7fa2156ae7f053044df4c43aa2bad831dc166694c",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-i386:8a39d1f803b6bd6db6a5a231b5a4e2fc1d7fc13a10e22dd28cb25e16429b16fd@sha256:e56f38e952dd40f4f3e5d6f970e8868239e199efba77c43c8ad5f387f24de2fa"
+			}
+		},
+		"oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "i386",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9",
+						"org.opencontainers.image.revision": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "386",
+						"os": "linux"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-i386:e64948c9285dce77f3354b819bebb332429012bee6c55391e2201a49e7a02090@sha256:27518fc8de1793263dc386111bb80b500ce3b5efd45fdab5283230ae837f00a7"
+			}
+		},
+		"oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "mips64le",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8",
+						"org.opencontainers.image.revision": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "mips64le",
+						"os": "linux"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-mips64le:266da6320ef4524a6eb4a9ff40df1a63770f3cb24becc351b4ec2a7da75e76a3@sha256:cd875943c751833209130bc3737ab5b7d6dd9fadf43093fa965ac04a45567dbc"
+			}
+		},
+		"oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "ppc64le",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89",
+						"org.opencontainers.image.revision": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "ppc64le",
+						"os": "linux"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:4fbef42648bc144fb17186958f9bc3fea48461be4fa04640dc41a2465d9bb230@sha256:4899d0c4bc83bb2086ba23907bd4eee0f79d590dd037c60fbbea545b6232088e"
+			}
+		},
+		"oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "ppc64le",
+						"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "server-0.7.0"
+					},
+					"platform": {
+						"architecture": "ppc64le",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:6235a23c8e809f36b0e6a6ef45efe0079f9a92ddb62d4ac397241074b79d42c7",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "ppc64le",
+						"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:6235a23c8e809f36b0e6a6ef45efe0079f9a92ddb62d4ac397241074b79d42c7",
+						"vnd.docker.reference.digest": "sha256:ead953dd52edeea966545664b2c9fec2e1bb4d3a79671f95190819095351f641",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:c72366c942fc80dc984291207128f5df861e483aa0233ce6495c8a6e1c5d0918@sha256:f4e1aff8b7e19c3842fb78b2be1e65ec9290e7c6783f087c813987b36400587a"
+			}
+		},
+		"oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "ppc64le",
+						"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "signer-0.7.0"
+					},
+					"platform": {
+						"architecture": "ppc64le",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:d777a1b17cf821e4518af7210ec644a565bb09521fc8fed18cbb00b146457adc",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "ppc64le",
+						"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:d777a1b17cf821e4518af7210ec644a565bb09521fc8fed18cbb00b146457adc",
+						"vnd.docker.reference.digest": "sha256:8eb5fb1e9d7895f95d2c6485df3c1d62ae867114699be79bf388b931c587865d",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-ppc64le:fe5b5efb1e03f722dcda7652bd3f61f4f727dc2e9fe52d03ca626a9cf1ac849f@sha256:63b53ff8f8a08587f2dfe1f9dfbfd3bb3dc1e99ccf00cdf4c7c879ff947d50b3"
+			}
+		},
+		"oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:f681eed9b2db497321012a47fa83f50edccb5ae789b07dea2e608e81e05f5899",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "riscv64",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:f681eed9b2db497321012a47fa83f50edccb5ae789b07dea2e608e81e05f5899",
+						"org.opencontainers.image.revision": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-uclibc"
+					},
+					"platform": {
+						"architecture": "riscv64",
+						"os": "linux"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-riscv64:9235655eb06d0f7236ccf163b78621920c0b45632d1032053eb43ebc293d2588@sha256:40d18300f578ca6dd6f7feaccb047555b9348514a7a495be637732f50de54dcc"
+			}
+		},
+		"oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "s390x",
+						"org.opencontainers.image.ref.name": "oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-signer",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "signer-0.7.0"
+					},
+					"platform": {
+						"architecture": "s390x",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:c84dbdb9b42aafc6e1def960ec053709e57577b1eb06ea6cdb66da0e94acc640",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "s390x",
+						"org.opencontainers.image.ref.name": "oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:c84dbdb9b42aafc6e1def960ec053709e57577b1eb06ea6cdb66da0e94acc640",
+						"vnd.docker.reference.digest": "sha256:23b5119f61f785a5bc3d0e08d81069495e7b7812a69f15f6894ff355737dee38",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-s390x:7ea69d395a11993aaef4cd29dd58bbcfe6189e984c367ed781fb4dd4bdb9ff60@sha256:562fb5f01ca7174dc55991dbfab646c5c742a2079f5792762700b25fef76bfbd"
+			}
+		},
+		"oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6",
+					"size": 610,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "s390x",
+						"org.opencontainers.image.base.name": "scratch",
+						"org.opencontainers.image.created": "2024-02-28T00:44:18Z",
+						"org.opencontainers.image.ref.name": "oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6",
+						"org.opencontainers.image.revision": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
+						"org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
+						"org.opencontainers.image.version": "1.36.1-glibc"
+					},
+					"platform": {
+						"architecture": "s390x",
+						"os": "linux"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-s390x:92cb7e2c6d22e7f54452c93522e5708b01c944f2f5e7a5b84ac6266652e48066@sha256:15ef327d3dec3c4e9510f2ae1f3e737b9c443c566b70a51ef97776debc9bfd9c"
+			}
+		},
+		"oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.oci.image.index.v1+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
+					"size": 1998,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "s390x",
+						"org.opencontainers.image.ref.name": "oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
+						"org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+						"org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+						"org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+						"org.opencontainers.image.version": "server-0.7.0"
+					},
+					"platform": {
+						"architecture": "s390x",
+						"os": "linux"
+					}
+				},
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest": "sha256:c35c2d748647d9150a218c6f9bba1ba76b2857c71608e21de4dea7e277400a5f",
+					"size": 839,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "s390x",
+						"org.opencontainers.image.ref.name": "oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:c35c2d748647d9150a218c6f9bba1ba76b2857c71608e21de4dea7e277400a5f",
+						"vnd.docker.reference.digest": "sha256:66118e7982bb814a9d939808797fc0e073194732d5bcdb0afaa98c515d17ab23",
+						"vnd.docker.reference.type": "attestation-manifest"
+					},
+					"platform": {
+						"architecture": "unknown",
+						"os": "unknown"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-s390x:bcf9a20ccb4e460c190294d900a06bfce1b9d9c703358b3f87ae0de4b30abf11@sha256:8b50da43831c731e8504c0b11dfb1573b3096428c780539b77db32ae76653199"
+			}
+		},
+		"oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+					"digest": "sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021",
+					"size": 3462,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "windows-amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
+					},
+					"platform": {
+						"architecture": "amd64",
+						"os": "windows",
+						"os.version": "10.0.17763.5122"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:5efe68ed819e46db05a9b50e99c758feaf96df829939aca311b55e42df521acf@sha256:040cdf6cf38b4693b30bb38cae806e8b456d4458c2c257fb26d48e45c83b1021"
+			}
+		},
+		"oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e": {
+			"schemaVersion": 2,
+			"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+			"manifests": [
+				{
+					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+					"digest": "sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce",
+					"size": 3462,
+					"annotations": {
+						"com.docker.official-images.bashbrew.arch": "windows-amd64",
+						"org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+					},
+					"platform": {
+						"architecture": "amd64",
+						"os": "windows",
+						"os.version": "10.0.20348.2113"
+					}
+				}
+			],
+			"annotations": {
+				"org.opencontainers.image.ref.name": "oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
 			}
 		}
 	}

--- a/.test/lookup-test.json
+++ b/.test/lookup-test.json
@@ -9,7 +9,7 @@
         "size": 946,
         "annotations": {
           "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "docker.io/tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
+          "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
         },
         "platform": {
           "architecture": "amd64",
@@ -19,7 +19,7 @@
       }
     ],
     "annotations": {
-      "org.opencontainers.image.ref.name": "docker.io/tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
+      "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
     }
   },
   {
@@ -32,7 +32,7 @@
         "size": 861,
         "annotations": {
           "com.docker.official-images.bashbrew.arch": "amd64",
-          "org.opencontainers.image.ref.name": "docker.io/tianon/test@sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
+          "org.opencontainers.image.ref.name": "tianon/test@sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
           "org.opencontainers.image.revision": "3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee",
           "org.opencontainers.image.source": "https://github.com/docker-library/hello-world.git#3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee:amd64/hello-world",
           "org.opencontainers.image.url": "https://hub.docker.com/_/hello-world",
@@ -49,7 +49,7 @@
         "size": 946,
         "annotations": {
           "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "docker.io/tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
+          "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
         },
         "platform": {
           "architecture": "amd64",
@@ -63,7 +63,7 @@
         "size": 946,
         "annotations": {
           "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "docker.io/tianon/test@sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5"
+          "org.opencontainers.image.ref.name": "tianon/test@sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5"
         },
         "platform": {
           "architecture": "amd64",
@@ -73,7 +73,7 @@
       }
     ],
     "annotations": {
-      "org.opencontainers.image.ref.name": "docker.io/tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
+      "org.opencontainers.image.ref.name": "tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
     }
   }
 ]

--- a/cmd/builds/main.go
+++ b/cmd/builds/main.go
@@ -55,7 +55,7 @@ var (
 )
 
 func resolveIndex(ctx context.Context, img string, diskCacheForSure bool) (*ocispec.Index, error) {
-	ref, err := registry.ParseRefNormalized(img)
+	ref, err := registry.ParseRef(img)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func resolveIndex(ctx context.Context, img string, diskCacheForSure bool) (*ocis
 	if diskCacheForSure {
 		saveCacheMutex.Lock()
 		if saveCache != nil {
-			saveCache.Indexes[refString] = index
+			saveCache.Indexes[ref] = index
 		}
 		saveCacheMutex.Unlock()
 	}
@@ -137,7 +137,7 @@ func resolveArchIndex(ctx context.Context, img string, arch string, diskCacheFor
 }
 
 type cacheFileContents struct {
-	Indexes map[string]*ocispec.Index `json:"indexes"`
+	Indexes map[registry.Reference]*ocispec.Index `json:"indexes"`
 }
 
 var (
@@ -152,7 +152,7 @@ func loadCacheFromFile() error {
 
 	// now that we know we have a file we want cache to go into (and come from), let's initialize the "saveCache" (which will be written when the whole process is done / we're successful, and *only* caches staging images)
 	saveCacheMutex.Lock()
-	saveCache = &cacheFileContents{Indexes: map[string]*ocispec.Index{}}
+	saveCache = &cacheFileContents{Indexes: map[registry.Reference]*ocispec.Index{}}
 	saveCacheMutex.Unlock()
 
 	f, err := os.Open(cacheFile)
@@ -180,7 +180,7 @@ func loadCacheFromFile() error {
 			panic(err)
 		}
 		if index2 != index {
-			panic("index2 != index??? " + img)
+			panic("index2 != index??? " + img.String())
 		}
 	}
 

--- a/cmd/lookup/main.go
+++ b/cmd/lookup/main.go
@@ -16,7 +16,7 @@ func main() {
 	defer stop()
 
 	for _, img := range os.Args[1:] {
-		ref, err := registry.ParseRefNormalized(img)
+		ref, err := registry.ParseRef(img)
 		if err != nil {
 			panic(err)
 		}

--- a/registry/ref.go
+++ b/registry/ref.go
@@ -10,16 +10,26 @@ import (
 	"cuelabs.dev/go/oci/ociregistry/ociref"
 )
 
-// parse a ref like `hello-world:latest` into an [ociref.Reference] object, with Docker Hub canonicalization applied: `docker.io/library/hello-world:latest`
+// parse a string ref like `hello-world:latest` directly into a [Reference] object, with Docker Hub canonicalization applied: `docker.io/library/hello-world:latest`
 //
-// See also [ociref.ParseRelative]
+// See also [Reference.Normalize] and [ociref.ParseRelative] (which are the underlying implementation details of this method).
+func ParseRef(img string) (Reference, error) {
+	r, err := ociref.ParseRelative(img)
+	if err != nil {
+		return Reference{}, err
+	}
+	ref := Reference(r)
+	ref.Normalize()
+	return ref, nil
+}
+
+// copy ociref.Reference so we can add methods (especially for JSON round-trip, but also Docker-isms like the implied default [Reference.Host] and `library/` prefix for DOI)
+type Reference ociref.Reference
+
+// normalize Docker Hub refs like `hello-world:latest`: `docker.io/library/hello-world:latest`
 //
 // NOTE: this explicitly does *not* normalize Tag to `:latest` because it's useful to be able to parse a reference and know it did not specify either tag or digest (and `if ref.Tag == "" { ref.Tag = "latest" }` is really trivial code outside this for that case)
-func ParseRefNormalized(img string) (ociref.Reference, error) {
-	ref, err := ociref.ParseRelative(img)
-	if err != nil {
-		return ociref.Reference{}, err
-	}
+func (ref *Reference) Normalize() {
 	if dockerHubHosts[ref.Host] {
 		// normalize Docker Hub host value
 		ref.Host = dockerHubCanonical
@@ -27,6 +37,29 @@ func ParseRefNormalized(img string) (ociref.Reference, error) {
 		if !strings.Contains(ref.Repository, "/") {
 			ref.Repository = "library/" + ref.Repository
 		}
+		// add an error return and return an error if we have more than one "/" in Repository?  probably not worth embedding that many "Hub" implementation details this low (since it'll error appropriately on use of such invalid references anyhow)
 	}
-	return ref, nil
+}
+
+// like [ociref.Reference.String], but with Docker Hub "denormalization" applied (no explicit `docker.io` host, no `library/` prefix for DOI)
+func (ref Reference) String() string {
+	if ref.Host == dockerHubCanonical {
+		ref.Host = ""
+		ref.Repository = strings.TrimPrefix(ref.Repository, "library/")
+	}
+	return ociref.Reference(ref).String()
+}
+
+// implements [encoding.TextMarshaler] (especially for [Reference]-in-JSON)
+func (ref Reference) MarshalText() ([]byte, error) {
+	return []byte(ref.String()), nil
+}
+
+// implements [encoding.TextUnmarshaler] (especially for [Reference]-from-JSON)
+func (ref *Reference) UnmarshalText(text []byte) error {
+	r, err := ParseRef(string(text))
+	if err == nil {
+		*ref = r
+	}
+	return err
 }

--- a/registry/ref_test.go
+++ b/registry/ref_test.go
@@ -1,12 +1,33 @@
 package registry_test
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/docker-library/meta-scripts/registry"
+
+	"cuelabs.dev/go/oci/ociregistry/ociref"
 )
 
-func TestParseRefNormalized(t *testing.T) {
+func toJson(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal("unexpected JSON error", err)
+	}
+	return string(b)
+}
+
+func fromJson(t *testing.T, j string, v any) {
+	t.Helper()
+	err := json.Unmarshal([]byte(j), v)
+	if err != nil {
+		t.Fatal("unexpected JSON error", err)
+	}
+}
+
+func TestParseRef(t *testing.T) {
 	t.Parallel()
 
 	for _, o := range []struct {
@@ -28,17 +49,38 @@ func TestParseRefNormalized(t *testing.T) {
 		{"registry.hub.docker.com/library/hello-world", "docker.io/library/hello-world"},
 	} {
 		o := o // https://github.com/golang/go/issues/60078
+		dockerOut := strings.TrimPrefix(strings.TrimPrefix(o.out, "docker.io/library/"), "docker.io/")
+
 		t.Run(o.in, func(t *testing.T) {
-			ref, err := registry.ParseRefNormalized(o.in)
+			ref, err := registry.ParseRef(o.in)
 			if err != nil {
 				t.Fatal("unexpected error", err)
-				return
 			}
 
-			out := ref.String()
+			out := ociref.Reference(ref).String()
 			if out != o.out {
 				t.Fatalf("expected %q, got %q", o.out, out)
-				return
+			}
+
+			out = ref.String()
+			if out != dockerOut {
+				t.Fatalf("expected %q, got %q", dockerOut, out)
+			}
+		})
+
+		t.Run(o.in+" JSON", func(t *testing.T) {
+			json := toJson(t, o.in) // "hello-world:latest" (string straight to JSON so we can unmarshal it as a Reference)
+			var ref registry.Reference
+			fromJson(t, json, &ref)
+			out := ociref.Reference(ref).String()
+			if out != o.out {
+				t.Fatalf("expected %q, got %q", o.out, out)
+			}
+
+			json = toJson(t, ref)   // "hello-world:latest" (take our reference and convert it to JSON so we can verify it goes out correctly)
+			fromJson(t, json, &out) // back to a string
+			if out != dockerOut {
+				t.Fatalf("expected %q, got %q", dockerOut, out)
 			}
 		})
 	}

--- a/registry/synthesize-index.go
+++ b/registry/synthesize-index.go
@@ -9,12 +9,11 @@ import (
 	"github.com/docker-library/bashbrew/architecture"
 
 	"cuelabs.dev/go/oci/ociregistry"
-	"cuelabs.dev/go/oci/ociregistry/ociref"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // returns a synthesized [ocispec.Index] object for the given reference that includes automatically pulling up [ocispec.Platform] objects for entries missing them plus annotations for bashbrew architecture ([AnnotationBashbrewArch]) and where to find the "upstream" object if it needs to be copied/pulled ([ocispec.AnnotationRefName])
-func SynthesizeIndex(ctx context.Context, ref ociref.Reference) (*ocispec.Index, error) {
+func SynthesizeIndex(ctx context.Context, ref Reference) (*ocispec.Index, error) {
 	// consider making this a full ociregistry.Interface object? GetManifest(digest) not returning an object with that digest would certainly be Weird though so maybe that's a misguided idea (with very minimal actual benefit, at least right now)
 
 	client, err := Client(ref.Host, nil)
@@ -137,8 +136,8 @@ func SynthesizeIndex(ctx context.Context, ref ociref.Reference) (*ocispec.Index,
 	return &index, nil
 }
 
-// given a (potentially `nil`) map of annotations, add [ocispec.AnnotationRefName] including the supplied [ociref.Reference] (but with [ociref.Reference.Digest] set to a new value)
-func setRefAnnotation(annotations *map[string]string, ref ociref.Reference, digest ociregistry.Digest) {
+// given a (potentially `nil`) map of annotations, add [ocispec.AnnotationRefName] including the supplied [Reference] (but with [Reference.Digest] set to a new value)
+func setRefAnnotation(annotations *map[string]string, ref Reference, digest ociregistry.Digest) {
 	if *annotations == nil {
 		// "assignment to nil map" 🙃
 		*annotations = map[string]string{}
@@ -148,7 +147,7 @@ func setRefAnnotation(annotations *map[string]string, ref ociref.Reference, dige
 }
 
 // given a manifest descriptor (and optionally an existing [ociregistry.BlobReader] on the manifest object itself), make sure it has a valid [ocispec.Platform] object if possible, querying down into the [ocispec.Image] ("config" blob) if necessary
-func normalizeManifestPlatform(ctx context.Context, m *ocispec.Descriptor, r ociregistry.BlobReader, client ociregistry.Interface, ref ociref.Reference) error {
+func normalizeManifestPlatform(ctx context.Context, m *ocispec.Descriptor, r ociregistry.BlobReader, client ociregistry.Interface, ref Reference) error {
 	if m.Platform == nil || m.Platform.OS == "" || m.Platform.Architecture == "" {
 		// if missing (or obviously invalid) "platform", we need to (maybe) reach downwards and synthesize
 		m.Platform = nil


### PR DESCRIPTION
This also allows us to add explicit JSON round-tripping which can handle normalizing/denormalizing for us, so our output strings no longer contain `docker.io/[library/]`. 🎉