### PR TITLE
Also treat 401 as if it were 404

### DIFF
--- a/registry/synthesize-index.go
+++ b/registry/synthesize-index.go
@@ -37,7 +37,9 @@ func SynthesizeIndex(ctx context.Context, ref ociref.Reference) (*ocispec.Index,
 		if errors.Is(err, ociregistry.ErrBlobUnknown) ||
 			errors.Is(err, ociregistry.ErrManifestUnknown) ||
 			errors.Is(err, ociregistry.ErrNameUnknown) ||
-			strings.HasPrefix(err.Error(), "404 ") {
+			strings.HasPrefix(err.Error(), "404 ") ||
+			// 401 often means "repository not found" (due to the nature of public/private mixing on Hub and the fact that ociauth definitely handled any possible authentication for us, so if we're still getting 401 it's unavoidable and might as well be 404)
+			strings.HasPrefix(err.Error(), "401 ") {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("%s: failed GET: %w", ref, err)


### PR DESCRIPTION
We recently ran into this again with `arm32v6/hello-world` where 401 from the proxy actually means 404 because of mixing + matching public/private repositories in the same registry/namespace and thus returning a true 404 would be an information leak.  In our case, if we get a 401 at this point, we know for sure it might as well be a 404 because `ociauth` would already have handled any authentication we could possibly do.