### PR TITLE
Update registry cache to (ab)use `Data` field of `Descriptor` objects

### DIFF
--- a/.test/lookup-test.json
+++ b/.test/lookup-test.json
@@ -1,268 +1,374 @@
 [
-  {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-    "manifests": [
-      {
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "digest": "sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23",
-        "size": 946,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
-        },
-        "platform": {
-          "architecture": "amd64",
-          "os": "windows",
-          "os.version": "10.0.20348.2340"
-        }
-      }
+  [
+    [
+      "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
     ],
-    "annotations": {
-      "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
-    }
-  },
-  {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "manifests": [
-      {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
-        "size": 861,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "amd64",
-          "org.opencontainers.image.ref.name": "tianon/test@sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
-          "org.opencontainers.image.revision": "3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee",
-          "org.opencontainers.image.source": "https://github.com/docker-library/hello-world.git#3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee:amd64/hello-world",
-          "org.opencontainers.image.url": "https://hub.docker.com/_/hello-world",
-          "org.opencontainers.image.version": "linux"
-        },
-        "platform": {
-          "architecture": "amd64",
-          "os": "linux"
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+          "digest": "sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23",
+          "size": 946,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "windows-amd64",
+            "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
+          },
+          "platform": {
+            "architecture": "amd64",
+            "os": "windows",
+            "os.version": "10.0.20348.2340"
+          }
         }
-      },
-      {
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "digest": "sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23",
-        "size": 946,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
-        },
-        "platform": {
-          "architecture": "amd64",
-          "os": "windows",
-          "os.version": "10.0.20348.2340"
-        }
-      },
-      {
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "digest": "sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5",
-        "size": 946,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "tianon/test@sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5"
-        },
-        "platform": {
-          "architecture": "amd64",
-          "os": "windows",
-          "os.version": "10.0.17763.5576"
-        }
+      ],
+      "annotations": {
+        "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
       }
+    }
+  ],
+  [
+    [
+      "tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
     ],
-    "annotations": {
-      "org.opencontainers.image.ref.name": "tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
-    }
-  },
-  {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "manifests": [
-      {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
-        "size": 861,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "amd64",
-          "org.opencontainers.image.ref.name": "hello-world@sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
-          "org.opencontainers.image.revision": "3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee",
-          "org.opencontainers.image.source": "https://github.com/docker-library/hello-world.git#3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee:amd64/hello-world",
-          "org.opencontainers.image.url": "https://hub.docker.com/_/hello-world",
-          "org.opencontainers.image.version": "linux"
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
+          "size": 861,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "amd64",
+            "org.opencontainers.image.ref.name": "tianon/test@sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
+            "org.opencontainers.image.revision": "3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee",
+            "org.opencontainers.image.source": "https://github.com/docker-library/hello-world.git#3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee:amd64/hello-world",
+            "org.opencontainers.image.url": "https://hub.docker.com/_/hello-world",
+            "org.opencontainers.image.version": "linux"
+          },
+          "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+          }
+        },
+        {
+          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+          "digest": "sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23",
+          "size": 946,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "windows-amd64",
+            "org.opencontainers.image.ref.name": "tianon/test@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
+          },
+          "platform": {
+            "architecture": "amd64",
+            "os": "windows",
+            "os.version": "10.0.20348.2340"
+          }
+        },
+        {
+          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+          "digest": "sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5",
+          "size": 946,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "windows-amd64",
+            "org.opencontainers.image.ref.name": "tianon/test@sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5"
+          },
+          "platform": {
+            "architecture": "amd64",
+            "os": "windows",
+            "os.version": "10.0.17763.5576"
+          }
         }
-      },
-      {
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "digest": "sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23",
-        "size": 946,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "hello-world@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
-        }
-      },
-      {
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "digest": "sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5",
-        "size": 946,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "windows-amd64",
-          "org.opencontainers.image.ref.name": "hello-world@sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5"
-        }
+      ],
+      "annotations": {
+        "org.opencontainers.image.ref.name": "tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
       }
-    ]
-  },
-  "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9oZWxsbyJdLCJXb3JraW5nRGlyIjoiLyIsIkFyZ3NFc2NhcGVkIjp0cnVlLCJPbkJ1aWxkIjpudWxsfSwiY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiaGlzdG9yeSI6W3siY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiY3JlYXRlZF9ieSI6IkNPUFkgaGVsbG8gLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIzLTA1LTAyVDE2OjQ5OjI3WiIsImNyZWF0ZWRfYnkiOiJDTUQgW1wiL2hlbGxvXCJdIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YWMyODgwMGVjOGJiMzhkNWMzNWI0OWQ0NWE2YWM0Nzc3NTQ0OTQxMTk5MDc1ZGZmOGM0ZWI2M2UwOTNhYTgxZSJdfX0=",
-  {
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "digest": "sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac",
-    "size": 1649,
-    "data": "ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLmluZGV4LnYxK2pzb24iLAoJIm1hbmlmZXN0cyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5tYW5pZmVzdC52MStqc29uIiwKCQkJImRpZ2VzdCI6ICJzaGEyNTY6ZTJmYzRlNTAxMmQxNmU3ZmU0NjZmNTI5MWM0NzY0MzFiZWFhMWY5YjkwYTVjMjEyNWI0OTNlZDI4ZTJhYmE1NyIsCgkJCSJzaXplIjogODYxLAoJCQkiYW5ub3RhdGlvbnMiOiB7CgkJCQkiY29tLmRvY2tlci5vZmZpY2lhbC1pbWFnZXMuYmFzaGJyZXcuYXJjaCI6ICJhbWQ2NCIsCgkJCQkib3JnLm9wZW5jb250YWluZXJzLmltYWdlLnJlZi5uYW1lIjogImhlbGxvLXdvcmxkQHNoYTI1NjplMmZjNGU1MDEyZDE2ZTdmZTQ2NmY1MjkxYzQ3NjQzMWJlYWExZjliOTBhNWMyMTI1YjQ5M2VkMjhlMmFiYTU3IiwKCQkJCSJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UucmV2aXNpb24iOiAiM2ZiNmViY2E0MTYzYmY1YjljYzQ5NmFjM2U4ZjExY2IxZTc1NGFlZSIsCgkJCQkib3JnLm9wZW5jb250YWluZXJzLmltYWdlLnNvdXJjZSI6ICJodHRwczovL2dpdGh1Yi5jb20vZG9ja2VyLWxpYnJhcnkvaGVsbG8td29ybGQuZ2l0IzNmYjZlYmNhNDE2M2JmNWI5Y2M0OTZhYzNlOGYxMWNiMWU3NTRhZWU6YW1kNjQvaGVsbG8td29ybGQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS51cmwiOiAiaHR0cHM6Ly9odWIuZG9ja2VyLmNvbS9fL2hlbGxvLXdvcmxkIiwKCQkJCSJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UudmVyc2lvbiI6ICJsaW51eCIKCQkJfQoJCX0sCgkJewoJCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLAoJCQkiZGlnZXN0IjogInNoYTI1NjoyZjE5Y2UyNzYzMmU2YmFmNGViYjFiNTgyOTYwZDY4OTQ4ZTUyOTAyYzhjZmFjMTAxMzNkYTAwNThmMWRhYjIzIiwKCQkJInNpemUiOiA5NDYsCgkJCSJhbm5vdGF0aW9ucyI6IHsKCQkJCSJjb20uZG9ja2VyLm9mZmljaWFsLWltYWdlcy5iYXNoYnJldy5hcmNoIjogIndpbmRvd3MtYW1kNjQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5yZWYubmFtZSI6ICJoZWxsby13b3JsZEBzaGEyNTY6MmYxOWNlMjc2MzJlNmJhZjRlYmIxYjU4Mjk2MGQ2ODk0OGU1MjkwMmM4Y2ZhYzEwMTMzZGEwMDU4ZjFkYWIyMyIKCQkJfQoJCX0sCgkJewoJCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLAoJCQkiZGlnZXN0IjogInNoYTI1NjozYTBiZDBmYjVhZDZkZDY1MjhkYzc4NzI2YjNkZjc4ZTk4MGIzOWIzNzllOTljNWE1MDg5MDRlYzE3Y2ZhZmU1IiwKCQkJInNpemUiOiA5NDYsCgkJCSJhbm5vdGF0aW9ucyI6IHsKCQkJCSJjb20uZG9ja2VyLm9mZmljaWFsLWltYWdlcy5iYXNoYnJldy5hcmNoIjogIndpbmRvd3MtYW1kNjQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5yZWYubmFtZSI6ICJoZWxsby13b3JsZEBzaGEyNTY6M2EwYmQwZmI1YWQ2ZGQ2NTI4ZGM3ODcyNmIzZGY3OGU5ODBiMzliMzc5ZTk5YzVhNTA4OTA0ZWMxN2NmYWZlNSIKCQkJfQoJCX0KCV0KfQo="
-  },
-  {
-    "mediaType": "application/octet-stream",
-    "digest": "sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a",
-    "size": 581,
-    "data": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9oZWxsbyJdLCJXb3JraW5nRGlyIjoiLyIsIkFyZ3NFc2NhcGVkIjp0cnVlLCJPbkJ1aWxkIjpudWxsfSwiY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiaGlzdG9yeSI6W3siY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiY3JlYXRlZF9ieSI6IkNPUFkgaGVsbG8gLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIzLTA1LTAyVDE2OjQ5OjI3WiIsImNyZWF0ZWRfYnkiOiJDTUQgW1wiL2hlbGxvXCJdIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YWMyODgwMGVjOGJiMzhkNWMzNWI0OWQ0NWE2YWM0Nzc3NTQ0OTQxMTk5MDc1ZGZmOGM0ZWI2M2UwOTNhYTgxZSJdfX0="
-  },
-  {
-    "mediaType": "application/octet-stream",
-    "digest": "sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e",
-    "size": 396
-  },
-  {
-    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-    "digest": "sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d",
-    "size": 1165
-  },
-  "ewoJImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCgkiY29uZmlnIjogewoJCSJDbWQiOiBbCgkJCSIvdHJ1ZSIKCQldCgl9LAoJImNyZWF0ZWQiOiAiMjAyMy0wMi0wMVQwNjo1MToxMVoiLAoJImhpc3RvcnkiOiBbCgkJewoJCQkiY3JlYXRlZCI6ICIyMDIzLTAyLTAxVDA2OjUxOjExWiIsCgkJCSJjcmVhdGVkX2J5IjogImh0dHBzOi8vZ2l0aHViLmNvbS90aWFub24vZG9ja2VyZmlsZXMvdHJlZS9tYXN0ZXIvdHJ1ZSIKCQl9CgldLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJImRpZmZfaWRzIjogWwoJCQkic2hhMjU2OjY1YjVhNDU5M2NjNjFkM2VhNmQzNTVmYjk3YzA0MzBkODIwZWUyMWFhODUzNWY1ZGU0NWU3NWMzMTk1NGI3NDMiCgkJXSwKCQkidHlwZSI6ICJsYXllcnMiCgl9Cn0K",
-  {
-    "config": {
-      "data": "ewoJImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCgkiY29uZmlnIjogewoJCSJDbWQiOiBbCgkJCSIvdHJ1ZSIKCQldCgl9LAoJImNyZWF0ZWQiOiAiMjAyMy0wMi0wMVQwNjo1MToxMVoiLAoJImhpc3RvcnkiOiBbCgkJewoJCQkiY3JlYXRlZCI6ICIyMDIzLTAyLTAxVDA2OjUxOjExWiIsCgkJCSJjcmVhdGVkX2J5IjogImh0dHBzOi8vZ2l0aHViLmNvbS90aWFub24vZG9ja2VyZmlsZXMvdHJlZS9tYXN0ZXIvdHJ1ZSIKCQl9CgldLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJImRpZmZfaWRzIjogWwoJCQkic2hhMjU2OjY1YjVhNDU5M2NjNjFkM2VhNmQzNTVmYjk3YzA0MzBkODIwZWUyMWFhODUzNWY1ZGU0NWU3NWMzMTk1NGI3NDMiCgkJXSwKCQkidHlwZSI6ICJsYXllcnMiCgl9Cn0K",
+    }
+  ],
+  [
+    [
+      "--type manifest",
+      "tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
+    ],
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
+          "size": 861,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "amd64",
+            "org.opencontainers.image.ref.name": "hello-world@sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
+            "org.opencontainers.image.revision": "3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee",
+            "org.opencontainers.image.source": "https://github.com/docker-library/hello-world.git#3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee:amd64/hello-world",
+            "org.opencontainers.image.url": "https://hub.docker.com/_/hello-world",
+            "org.opencontainers.image.version": "linux"
+          }
+        },
+        {
+          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+          "digest": "sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23",
+          "size": 946,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "windows-amd64",
+            "org.opencontainers.image.ref.name": "hello-world@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
+          }
+        },
+        {
+          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+          "digest": "sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5",
+          "size": 946,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "windows-amd64",
+            "org.opencontainers.image.ref.name": "hello-world@sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5"
+          }
+        }
+      ]
+    }
+  ],
+  [
+    [
+      "--type blob",
+      "tianon/test@sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a"
+    ],
+    "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9oZWxsbyJdLCJXb3JraW5nRGlyIjoiLyIsIkFyZ3NFc2NhcGVkIjp0cnVlLCJPbkJ1aWxkIjpudWxsfSwiY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiaGlzdG9yeSI6W3siY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiY3JlYXRlZF9ieSI6IkNPUFkgaGVsbG8gLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIzLTA1LTAyVDE2OjQ5OjI3WiIsImNyZWF0ZWRfYnkiOiJDTUQgW1wiL2hlbGxvXCJdIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YWMyODgwMGVjOGJiMzhkNWMzNWI0OWQ0NWE2YWM0Nzc3NTQ0OTQxMTk5MDc1ZGZmOGM0ZWI2M2UwOTNhYTgxZSJdfX0="
+  ],
+  [
+    [
+      "--head",
+      "--type manifest",
+      "tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
+    ],
+    {
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "digest": "sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac",
+      "size": 1649,
+      "data": "ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLmluZGV4LnYxK2pzb24iLAoJIm1hbmlmZXN0cyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5tYW5pZmVzdC52MStqc29uIiwKCQkJImRpZ2VzdCI6ICJzaGEyNTY6ZTJmYzRlNTAxMmQxNmU3ZmU0NjZmNTI5MWM0NzY0MzFiZWFhMWY5YjkwYTVjMjEyNWI0OTNlZDI4ZTJhYmE1NyIsCgkJCSJzaXplIjogODYxLAoJCQkiYW5ub3RhdGlvbnMiOiB7CgkJCQkiY29tLmRvY2tlci5vZmZpY2lhbC1pbWFnZXMuYmFzaGJyZXcuYXJjaCI6ICJhbWQ2NCIsCgkJCQkib3JnLm9wZW5jb250YWluZXJzLmltYWdlLnJlZi5uYW1lIjogImhlbGxvLXdvcmxkQHNoYTI1NjplMmZjNGU1MDEyZDE2ZTdmZTQ2NmY1MjkxYzQ3NjQzMWJlYWExZjliOTBhNWMyMTI1YjQ5M2VkMjhlMmFiYTU3IiwKCQkJCSJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UucmV2aXNpb24iOiAiM2ZiNmViY2E0MTYzYmY1YjljYzQ5NmFjM2U4ZjExY2IxZTc1NGFlZSIsCgkJCQkib3JnLm9wZW5jb250YWluZXJzLmltYWdlLnNvdXJjZSI6ICJodHRwczovL2dpdGh1Yi5jb20vZG9ja2VyLWxpYnJhcnkvaGVsbG8td29ybGQuZ2l0IzNmYjZlYmNhNDE2M2JmNWI5Y2M0OTZhYzNlOGYxMWNiMWU3NTRhZWU6YW1kNjQvaGVsbG8td29ybGQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS51cmwiOiAiaHR0cHM6Ly9odWIuZG9ja2VyLmNvbS9fL2hlbGxvLXdvcmxkIiwKCQkJCSJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UudmVyc2lvbiI6ICJsaW51eCIKCQkJfQoJCX0sCgkJewoJCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLAoJCQkiZGlnZXN0IjogInNoYTI1NjoyZjE5Y2UyNzYzMmU2YmFmNGViYjFiNTgyOTYwZDY4OTQ4ZTUyOTAyYzhjZmFjMTAxMzNkYTAwNThmMWRhYjIzIiwKCQkJInNpemUiOiA5NDYsCgkJCSJhbm5vdGF0aW9ucyI6IHsKCQkJCSJjb20uZG9ja2VyLm9mZmljaWFsLWltYWdlcy5iYXNoYnJldy5hcmNoIjogIndpbmRvd3MtYW1kNjQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5yZWYubmFtZSI6ICJoZWxsby13b3JsZEBzaGEyNTY6MmYxOWNlMjc2MzJlNmJhZjRlYmIxYjU4Mjk2MGQ2ODk0OGU1MjkwMmM4Y2ZhYzEwMTMzZGEwMDU4ZjFkYWIyMyIKCQkJfQoJCX0sCgkJewoJCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLAoJCQkiZGlnZXN0IjogInNoYTI1NjozYTBiZDBmYjVhZDZkZDY1MjhkYzc4NzI2YjNkZjc4ZTk4MGIzOWIzNzllOTljNWE1MDg5MDRlYzE3Y2ZhZmU1IiwKCQkJInNpemUiOiA5NDYsCgkJCSJhbm5vdGF0aW9ucyI6IHsKCQkJCSJjb20uZG9ja2VyLm9mZmljaWFsLWltYWdlcy5iYXNoYnJldy5hcmNoIjogIndpbmRvd3MtYW1kNjQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5yZWYubmFtZSI6ICJoZWxsby13b3JsZEBzaGEyNTY6M2EwYmQwZmI1YWQ2ZGQ2NTI4ZGM3ODcyNmIzZGY3OGU5ODBiMzliMzc5ZTk5YzVhNTA4OTA0ZWMxN2NmYWZlNSIKCQkJfQoJCX0KCV0KfQo="
+    }
+  ],
+  [
+    [
+      "--head",
+      "--type blob",
+      "tianon/test@sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a"
+    ],
+    {
+      "mediaType": "application/octet-stream",
+      "digest": "sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a",
+      "size": 581,
+      "data": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9oZWxsbyJdLCJXb3JraW5nRGlyIjoiLyIsIkFyZ3NFc2NhcGVkIjp0cnVlLCJPbkJ1aWxkIjpudWxsfSwiY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiaGlzdG9yeSI6W3siY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiY3JlYXRlZF9ieSI6IkNPUFkgaGVsbG8gLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIzLTA1LTAyVDE2OjQ5OjI3WiIsImNyZWF0ZWRfYnkiOiJDTUQgW1wiL2hlbGxvXCJdIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YWMyODgwMGVjOGJiMzhkNWMzNWI0OWQ0NWE2YWM0Nzc3NTQ0OTQxMTk5MDc1ZGZmOGM0ZWI2M2UwOTNhYTgxZSJdfX0="
+    }
+  ],
+  [
+    [
+      "--head",
+      "--type blob",
+      "tianon/true@sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e"
+    ],
+    {
+      "mediaType": "application/octet-stream",
       "digest": "sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e",
-      "mediaType": "application/vnd.oci.image.config.v1+json",
       "size": 396
-    },
-    "layers": [
-      {
-        "data": "H4sIAAAAAAACAyspKk1loDEwAAJTU1MwDQTotIGhuQmcDRE3MzM0YlAwYKADKC0uSSxSUGAYoaDe1ceNiZERzmdisGMA8SoYHMB8Byx6HBgsGGA6QDQrmiwyXQPl1cDlIUG9wYaflWEUDDgAAIAGdJIABAAA",
-        "digest": "sha256:1c51fc286aa95d9413226599576bafa38490b1e292375c90de095855b64caea6",
-        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-        "size": 117
-      }
-    ],
-    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-    "schemaVersion": 2
-  },
-  {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "manifests": [
-      {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d",
-        "size": 1165,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "amd64",
-          "org.opencontainers.image.ref.name": "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
-        },
-        "platform": {
-          "architecture": "amd64",
-          "os": "linux"
-        }
-      }
-    ],
-    "annotations": {
-      "org.opencontainers.image.ref.name": "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
     }
-  },
-  {
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "digest": "sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7",
-    "size": 1265
-  },
-  {
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "digest": "sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7",
-    "size": 1265
-  },
-  {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "manifests": [
-      {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-        "size": 1998,
-        "annotations": {
-          "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-          "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
-          "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-          "org.opencontainers.image.version": "server-0.7.0"
-        },
-        "platform": {
-          "architecture": "amd64",
-          "os": "linux"
-        }
-      },
-      {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
-        "size": 839,
-        "annotations": {
-          "vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-          "vnd.docker.reference.type": "attestation-manifest"
-        },
-        "platform": {
-          "architecture": "unknown",
-          "os": "unknown"
-        }
-      }
-    ]
-  },
-  {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "manifests": [
-      {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-        "size": 1998,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "amd64",
-          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-          "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
-          "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
-          "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
-          "org.opencontainers.image.version": "server-0.7.0"
-        },
-        "platform": {
-          "architecture": "amd64",
-          "os": "linux"
-        }
-      },
-      {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
-        "size": 839,
-        "annotations": {
-          "com.docker.official-images.bashbrew.arch": "amd64",
-          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
-          "vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
-          "vnd.docker.reference.type": "attestation-manifest"
-        },
-        "platform": {
-          "architecture": "unknown",
-          "os": "unknown"
-        }
-      }
+  ],
+  [
+    [
+      "--head",
+      "--type manifest",
+      "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
     ],
-    "annotations": {
-      "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7"
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d",
+      "size": 1165
     }
-  },
-  null,
-  null,
-  null
+  ],
+  [
+    [
+      "--type blob",
+      "tianon/true@sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e"
+    ],
+    "ewoJImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCgkiY29uZmlnIjogewoJCSJDbWQiOiBbCgkJCSIvdHJ1ZSIKCQldCgl9LAoJImNyZWF0ZWQiOiAiMjAyMy0wMi0wMVQwNjo1MToxMVoiLAoJImhpc3RvcnkiOiBbCgkJewoJCQkiY3JlYXRlZCI6ICIyMDIzLTAyLTAxVDA2OjUxOjExWiIsCgkJCSJjcmVhdGVkX2J5IjogImh0dHBzOi8vZ2l0aHViLmNvbS90aWFub24vZG9ja2VyZmlsZXMvdHJlZS9tYXN0ZXIvdHJ1ZSIKCQl9CgldLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJImRpZmZfaWRzIjogWwoJCQkic2hhMjU2OjY1YjVhNDU5M2NjNjFkM2VhNmQzNTVmYjk3YzA0MzBkODIwZWUyMWFhODUzNWY1ZGU0NWU3NWMzMTk1NGI3NDMiCgkJXSwKCQkidHlwZSI6ICJsYXllcnMiCgl9Cn0K"
+  ],
+  [
+    [
+      "--type manifest",
+      "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
+    ],
+    {
+      "config": {
+        "data": "ewoJImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCgkiY29uZmlnIjogewoJCSJDbWQiOiBbCgkJCSIvdHJ1ZSIKCQldCgl9LAoJImNyZWF0ZWQiOiAiMjAyMy0wMi0wMVQwNjo1MToxMVoiLAoJImhpc3RvcnkiOiBbCgkJewoJCQkiY3JlYXRlZCI6ICIyMDIzLTAyLTAxVDA2OjUxOjExWiIsCgkJCSJjcmVhdGVkX2J5IjogImh0dHBzOi8vZ2l0aHViLmNvbS90aWFub24vZG9ja2VyZmlsZXMvdHJlZS9tYXN0ZXIvdHJ1ZSIKCQl9CgldLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJImRpZmZfaWRzIjogWwoJCQkic2hhMjU2OjY1YjVhNDU5M2NjNjFkM2VhNmQzNTVmYjk3YzA0MzBkODIwZWUyMWFhODUzNWY1ZGU0NWU3NWMzMTk1NGI3NDMiCgkJXSwKCQkidHlwZSI6ICJsYXllcnMiCgl9Cn0K",
+        "digest": "sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e",
+        "mediaType": "application/vnd.oci.image.config.v1+json",
+        "size": 396
+      },
+      "layers": [
+        {
+          "data": "H4sIAAAAAAACAyspKk1loDEwAAJTU1MwDQTotIGhuQmcDRE3MzM0YlAwYKADKC0uSSxSUGAYoaDe1ceNiZERzmdisGMA8SoYHMB8Byx6HBgsGGA6QDQrmiwyXQPl1cDlIUG9wYaflWEUDDgAAIAGdJIABAAA",
+          "digest": "sha256:1c51fc286aa95d9413226599576bafa38490b1e292375c90de095855b64caea6",
+          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "size": 117
+        }
+      ],
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "schemaVersion": 2
+    }
+  ],
+  [
+    [
+      "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
+    ],
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d",
+          "size": 1165,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "amd64",
+            "org.opencontainers.image.ref.name": "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
+          },
+          "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+          }
+        }
+      ],
+      "annotations": {
+        "org.opencontainers.image.ref.name": "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
+      }
+    }
+  ],
+  [
+    [
+      "--head",
+      "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694"
+    ],
+    {
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "digest": "sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7",
+      "size": 1265
+    }
+  ],
+  [
+    [
+      "--head",
+      "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694"
+    ],
+    {
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "digest": "sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7",
+      "size": 1265
+    }
+  ],
+  [
+    [
+      "--type manifest",
+      "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694"
+    ],
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+          "size": 1998,
+          "annotations": {
+            "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+            "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+            "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+            "org.opencontainers.image.version": "server-0.7.0"
+          },
+          "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+          }
+        },
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+          "size": 839,
+          "annotations": {
+            "vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+            "vnd.docker.reference.type": "attestation-manifest"
+          },
+          "platform": {
+            "architecture": "unknown",
+            "os": "unknown"
+          }
+        }
+      ]
+    }
+  ],
+  [
+    [
+      "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694"
+    ],
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+          "size": 1998,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "amd64",
+            "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+            "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+            "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+            "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+            "org.opencontainers.image.version": "server-0.7.0"
+          },
+          "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+          }
+        },
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+          "size": 839,
+          "annotations": {
+            "com.docker.official-images.bashbrew.arch": "amd64",
+            "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+            "vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+            "vnd.docker.reference.type": "attestation-manifest"
+          },
+          "platform": {
+            "architecture": "unknown",
+            "os": "unknown"
+          }
+        }
+      ],
+      "annotations": {
+        "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7"
+      }
+    }
+  ],
+  [
+    [
+      "tianon/this-is-a-repository-that-will-never-ever-exist-$RANDOM-$RANDOM:$RANDOM-$RANDOM"
+    ],
+    null
+  ],
+  [
+    [
+      "--head",
+      "tianon/this-is-a-repository-that-will-never-ever-exist-$RANDOM-$RANDOM:$RANDOM-$RANDOM"
+    ],
+    null
+  ],
+  [
+    [
+      "tianon/test@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    ],
+    null
+  ]
 ]

--- a/.test/lookup-test.json
+++ b/.test/lookup-test.json
@@ -75,5 +75,194 @@
     "annotations": {
       "org.opencontainers.image.ref.name": "tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac"
     }
-  }
+  },
+  {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+      {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
+        "size": 861,
+        "annotations": {
+          "com.docker.official-images.bashbrew.arch": "amd64",
+          "org.opencontainers.image.ref.name": "hello-world@sha256:e2fc4e5012d16e7fe466f5291c476431beaa1f9b90a5c2125b493ed28e2aba57",
+          "org.opencontainers.image.revision": "3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee",
+          "org.opencontainers.image.source": "https://github.com/docker-library/hello-world.git#3fb6ebca4163bf5b9cc496ac3e8f11cb1e754aee:amd64/hello-world",
+          "org.opencontainers.image.url": "https://hub.docker.com/_/hello-world",
+          "org.opencontainers.image.version": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23",
+        "size": 946,
+        "annotations": {
+          "com.docker.official-images.bashbrew.arch": "windows-amd64",
+          "org.opencontainers.image.ref.name": "hello-world@sha256:2f19ce27632e6baf4ebb1b582960d68948e52902c8cfac10133da0058f1dab23"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5",
+        "size": 946,
+        "annotations": {
+          "com.docker.official-images.bashbrew.arch": "windows-amd64",
+          "org.opencontainers.image.ref.name": "hello-world@sha256:3a0bd0fb5ad6dd6528dc78726b3df78e980b39b379e99c5a508904ec17cfafe5"
+        }
+      }
+    ]
+  },
+  "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9oZWxsbyJdLCJXb3JraW5nRGlyIjoiLyIsIkFyZ3NFc2NhcGVkIjp0cnVlLCJPbkJ1aWxkIjpudWxsfSwiY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiaGlzdG9yeSI6W3siY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiY3JlYXRlZF9ieSI6IkNPUFkgaGVsbG8gLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIzLTA1LTAyVDE2OjQ5OjI3WiIsImNyZWF0ZWRfYnkiOiJDTUQgW1wiL2hlbGxvXCJdIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YWMyODgwMGVjOGJiMzhkNWMzNWI0OWQ0NWE2YWM0Nzc3NTQ0OTQxMTk5MDc1ZGZmOGM0ZWI2M2UwOTNhYTgxZSJdfX0=",
+  {
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "digest": "sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac",
+    "size": 1649,
+    "data": "ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLmluZGV4LnYxK2pzb24iLAoJIm1hbmlmZXN0cyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5tYW5pZmVzdC52MStqc29uIiwKCQkJImRpZ2VzdCI6ICJzaGEyNTY6ZTJmYzRlNTAxMmQxNmU3ZmU0NjZmNTI5MWM0NzY0MzFiZWFhMWY5YjkwYTVjMjEyNWI0OTNlZDI4ZTJhYmE1NyIsCgkJCSJzaXplIjogODYxLAoJCQkiYW5ub3RhdGlvbnMiOiB7CgkJCQkiY29tLmRvY2tlci5vZmZpY2lhbC1pbWFnZXMuYmFzaGJyZXcuYXJjaCI6ICJhbWQ2NCIsCgkJCQkib3JnLm9wZW5jb250YWluZXJzLmltYWdlLnJlZi5uYW1lIjogImhlbGxvLXdvcmxkQHNoYTI1NjplMmZjNGU1MDEyZDE2ZTdmZTQ2NmY1MjkxYzQ3NjQzMWJlYWExZjliOTBhNWMyMTI1YjQ5M2VkMjhlMmFiYTU3IiwKCQkJCSJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UucmV2aXNpb24iOiAiM2ZiNmViY2E0MTYzYmY1YjljYzQ5NmFjM2U4ZjExY2IxZTc1NGFlZSIsCgkJCQkib3JnLm9wZW5jb250YWluZXJzLmltYWdlLnNvdXJjZSI6ICJodHRwczovL2dpdGh1Yi5jb20vZG9ja2VyLWxpYnJhcnkvaGVsbG8td29ybGQuZ2l0IzNmYjZlYmNhNDE2M2JmNWI5Y2M0OTZhYzNlOGYxMWNiMWU3NTRhZWU6YW1kNjQvaGVsbG8td29ybGQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS51cmwiOiAiaHR0cHM6Ly9odWIuZG9ja2VyLmNvbS9fL2hlbGxvLXdvcmxkIiwKCQkJCSJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UudmVyc2lvbiI6ICJsaW51eCIKCQkJfQoJCX0sCgkJewoJCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLAoJCQkiZGlnZXN0IjogInNoYTI1NjoyZjE5Y2UyNzYzMmU2YmFmNGViYjFiNTgyOTYwZDY4OTQ4ZTUyOTAyYzhjZmFjMTAxMzNkYTAwNThmMWRhYjIzIiwKCQkJInNpemUiOiA5NDYsCgkJCSJhbm5vdGF0aW9ucyI6IHsKCQkJCSJjb20uZG9ja2VyLm9mZmljaWFsLWltYWdlcy5iYXNoYnJldy5hcmNoIjogIndpbmRvd3MtYW1kNjQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5yZWYubmFtZSI6ICJoZWxsby13b3JsZEBzaGEyNTY6MmYxOWNlMjc2MzJlNmJhZjRlYmIxYjU4Mjk2MGQ2ODk0OGU1MjkwMmM4Y2ZhYzEwMTMzZGEwMDU4ZjFkYWIyMyIKCQkJfQoJCX0sCgkJewoJCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLAoJCQkiZGlnZXN0IjogInNoYTI1NjozYTBiZDBmYjVhZDZkZDY1MjhkYzc4NzI2YjNkZjc4ZTk4MGIzOWIzNzllOTljNWE1MDg5MDRlYzE3Y2ZhZmU1IiwKCQkJInNpemUiOiA5NDYsCgkJCSJhbm5vdGF0aW9ucyI6IHsKCQkJCSJjb20uZG9ja2VyLm9mZmljaWFsLWltYWdlcy5iYXNoYnJldy5hcmNoIjogIndpbmRvd3MtYW1kNjQiLAoJCQkJIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5yZWYubmFtZSI6ICJoZWxsby13b3JsZEBzaGEyNTY6M2EwYmQwZmI1YWQ2ZGQ2NTI4ZGM3ODcyNmIzZGY3OGU5ODBiMzliMzc5ZTk5YzVhNTA4OTA0ZWMxN2NmYWZlNSIKCQkJfQoJCX0KCV0KfQo="
+  },
+  {
+    "mediaType": "application/octet-stream",
+    "digest": "sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a",
+    "size": 581,
+    "data": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9oZWxsbyJdLCJXb3JraW5nRGlyIjoiLyIsIkFyZ3NFc2NhcGVkIjp0cnVlLCJPbkJ1aWxkIjpudWxsfSwiY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiaGlzdG9yeSI6W3siY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTY6NDk6MjdaIiwiY3JlYXRlZF9ieSI6IkNPUFkgaGVsbG8gLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIzLTA1LTAyVDE2OjQ5OjI3WiIsImNyZWF0ZWRfYnkiOiJDTUQgW1wiL2hlbGxvXCJdIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YWMyODgwMGVjOGJiMzhkNWMzNWI0OWQ0NWE2YWM0Nzc3NTQ0OTQxMTk5MDc1ZGZmOGM0ZWI2M2UwOTNhYTgxZSJdfX0="
+  },
+  {
+    "mediaType": "application/octet-stream",
+    "digest": "sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e",
+    "size": 396
+  },
+  {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "digest": "sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d",
+    "size": 1165
+  },
+  "ewoJImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCgkiY29uZmlnIjogewoJCSJDbWQiOiBbCgkJCSIvdHJ1ZSIKCQldCgl9LAoJImNyZWF0ZWQiOiAiMjAyMy0wMi0wMVQwNjo1MToxMVoiLAoJImhpc3RvcnkiOiBbCgkJewoJCQkiY3JlYXRlZCI6ICIyMDIzLTAyLTAxVDA2OjUxOjExWiIsCgkJCSJjcmVhdGVkX2J5IjogImh0dHBzOi8vZ2l0aHViLmNvbS90aWFub24vZG9ja2VyZmlsZXMvdHJlZS9tYXN0ZXIvdHJ1ZSIKCQl9CgldLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJImRpZmZfaWRzIjogWwoJCQkic2hhMjU2OjY1YjVhNDU5M2NjNjFkM2VhNmQzNTVmYjk3YzA0MzBkODIwZWUyMWFhODUzNWY1ZGU0NWU3NWMzMTk1NGI3NDMiCgkJXSwKCQkidHlwZSI6ICJsYXllcnMiCgl9Cn0K",
+  {
+    "config": {
+      "data": "ewoJImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCgkiY29uZmlnIjogewoJCSJDbWQiOiBbCgkJCSIvdHJ1ZSIKCQldCgl9LAoJImNyZWF0ZWQiOiAiMjAyMy0wMi0wMVQwNjo1MToxMVoiLAoJImhpc3RvcnkiOiBbCgkJewoJCQkiY3JlYXRlZCI6ICIyMDIzLTAyLTAxVDA2OjUxOjExWiIsCgkJCSJjcmVhdGVkX2J5IjogImh0dHBzOi8vZ2l0aHViLmNvbS90aWFub24vZG9ja2VyZmlsZXMvdHJlZS9tYXN0ZXIvdHJ1ZSIKCQl9CgldLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJImRpZmZfaWRzIjogWwoJCQkic2hhMjU2OjY1YjVhNDU5M2NjNjFkM2VhNmQzNTVmYjk3YzA0MzBkODIwZWUyMWFhODUzNWY1ZGU0NWU3NWMzMTk1NGI3NDMiCgkJXSwKCQkidHlwZSI6ICJsYXllcnMiCgl9Cn0K",
+      "digest": "sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e",
+      "mediaType": "application/vnd.oci.image.config.v1+json",
+      "size": 396
+    },
+    "layers": [
+      {
+        "data": "H4sIAAAAAAACAyspKk1loDEwAAJTU1MwDQTotIGhuQmcDRE3MzM0YlAwYKADKC0uSSxSUGAYoaDe1ceNiZERzmdisGMA8SoYHMB8Byx6HBgsGGA6QDQrmiwyXQPl1cDlIUG9wYaflWEUDDgAAIAGdJIABAAA",
+        "digest": "sha256:1c51fc286aa95d9413226599576bafa38490b1e292375c90de095855b64caea6",
+        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "size": 117
+      }
+    ],
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "schemaVersion": 2
+  },
+  {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+      {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d",
+        "size": 1165,
+        "annotations": {
+          "com.docker.official-images.bashbrew.arch": "amd64",
+          "org.opencontainers.image.ref.name": "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
+        },
+        "platform": {
+          "architecture": "amd64",
+          "os": "linux"
+        }
+      }
+    ],
+    "annotations": {
+      "org.opencontainers.image.ref.name": "tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d"
+    }
+  },
+  {
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "digest": "sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7",
+    "size": 1265
+  },
+  {
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "digest": "sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7",
+    "size": 1265
+  },
+  {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+      {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+        "size": 1998,
+        "annotations": {
+          "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+          "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+          "org.opencontainers.image.version": "server-0.7.0"
+        },
+        "platform": {
+          "architecture": "amd64",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+        "size": 839,
+        "annotations": {
+          "vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+          "vnd.docker.reference.type": "attestation-manifest"
+        },
+        "platform": {
+          "architecture": "unknown",
+          "os": "unknown"
+        }
+      }
+    ]
+  },
+  {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+      {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+        "size": 1998,
+        "annotations": {
+          "com.docker.official-images.bashbrew.arch": "amd64",
+          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+          "org.opencontainers.image.revision": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "org.opencontainers.image.source": "https://github.com/docker/notary-official-images.git#77b9b7833f8dd6be07104b214193788795a320ff:notary-server",
+          "org.opencontainers.image.url": "https://hub.docker.com/_/notary",
+          "org.opencontainers.image.version": "server-0.7.0"
+        },
+        "platform": {
+          "architecture": "amd64",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+        "size": 839,
+        "annotations": {
+          "com.docker.official-images.bashbrew.arch": "amd64",
+          "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:692819af7e57efe94abadb451e05aa5eb042a540a2eae7095d37507dbd66dc94",
+          "vnd.docker.reference.digest": "sha256:4c3d07b2fed560ab0012452aa8a6f58533ddf2d4a3845fa89b74d9455816b454",
+          "vnd.docker.reference.type": "attestation-manifest"
+        },
+        "platform": {
+          "architecture": "unknown",
+          "os": "unknown"
+        }
+      }
+    ],
+    "annotations": {
+      "org.opencontainers.image.ref.name": "oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694@sha256:09dd1c0183f992a4507d6e562a8e079b8583d19aaf8d991b0d22711c6b4525d7"
+    }
+  },
+  null,
+  null,
+  null
 ]

--- a/.test/test.sh
+++ b/.test/test.sh
@@ -48,6 +48,30 @@ lookup=(
 	# tianon/test:index-no-platform-smaller - a "broken" index with *zero* platform objects in it (so every manifest requires a platform lookup)
 	'tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac'
 	# (doing these in the same run means the manifest from above should be cached and exercise more codepaths for better coverage)
+
+	--type manifest 'tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac' # same manifest again, but without SynthesizeIndex
+	--type blob 'tianon/test@sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a' # first config blob from the above
+	# and again, but this time HEADs
+	--head --type manifest 'tianon/test@sha256:347290ddd775c1b85a3e381b09edde95242478eb65153e9b17225356f4c072ac'
+	--head --type blob 'tianon/test@sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a'
+
+	# again with things that aren't cached yet (tianon/true:oci, specifically)
+	--head --type blob 'tianon/true@sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e' # config blob
+	--head --type manifest 'tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d'
+	--type blob 'tianon/true@sha256:25be82253336f0b8c4347bc4ecbbcdc85d0e0f118ccf8dc2e119c0a47a0a486e' # config blob
+	--type manifest 'tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d'
+	'tianon/true:oci@sha256:9ef42f1d602fb423fad935aac1caa0cfdbce1ad7edce64d080a4eb7b13f7cd9d'
+
+	# tag lookup! (but with a hopefully stable example tag -- a build of notary:server)
+	--head 'oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694'
+	--head 'oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694' # twice, to exercise "tag is cached" case
+	--type manifest 'oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694'
+	'oisupport/staging-amd64:71756dd75e41c4bc5144b64d36b4834a5a960c495470915eb69f96e9f2cb6694'
+
+	# exercise 404 codepaths
+	"tianon/this-is-a-repository-that-will-never-ever-exist-$RANDOM-$RANDOM:$RANDOM-$RANDOM"
+	--head "tianon/this-is-a-repository-that-will-never-ever-exist-$RANDOM-$RANDOM:$RANDOM-$RANDOM"
+	'tianon/test@sha256:0000000000000000000000000000000000000000000000000000000000000000'
 )
 "$dir/../bin/lookup" "${lookup[@]}" | jq -s > "$dir/lookup-test.json"
 

--- a/cmd/lookup/main.go
+++ b/cmd/lookup/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"os/signal"
 
@@ -15,21 +16,79 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	for _, img := range os.Args[1:] {
+	var (
+		zeroOpts registry.LookupOptions
+		opts     = zeroOpts
+	)
+
+	args := os.Args[1:]
+	for len(args) > 0 {
+		img := args[0]
+		args = args[1:]
+		switch img {
+		case "--type":
+			opts.Type = registry.LookupType(args[0])
+			args = args[1:]
+			continue
+		case "--head":
+			opts.Head = true
+			continue
+		}
+
 		ref, err := registry.ParseRef(img)
 		if err != nil {
 			panic(err)
 		}
 
-		index, err := registry.SynthesizeIndex(ctx, ref)
-		if err != nil {
-			panic(err)
+		var obj any
+		if opts == zeroOpts {
+			// if we have no explicit type and didn't request a HEAD, invoke SynthesizeIndex instead of Lookup
+			obj, err = registry.SynthesizeIndex(ctx, ref)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			r, err := registry.Lookup(ctx, ref, &opts)
+			if err != nil {
+				panic(err)
+			}
+			if r != nil {
+				desc := r.Descriptor()
+				if opts.Head {
+					obj = desc
+				} else {
+					b, err := io.ReadAll(r)
+					if err != nil {
+						r.Close()
+						panic(err)
+					}
+					if opts.Type == registry.LookupTypeManifest {
+						// if it was a manifest lookup, cast the byte slice to json.RawMessage so we get the actual JSON (not base64)
+						obj = json.RawMessage(b)
+					} else {
+						obj = b
+					}
+				}
+				err = r.Close()
+				if err != nil {
+					panic(err)
+				}
+			} else {
+				obj = nil
+			}
 		}
 
 		e := json.NewEncoder(os.Stdout)
 		e.SetIndent("", "\t")
-		if err := e.Encode(index); err != nil {
+		if err := e.Encode(obj); err != nil {
 			panic(err)
 		}
+
+		// reset state
+		opts = zeroOpts
+	}
+
+	if opts != zeroOpts {
+		panic("dangling --type, --head, etc (without a following reference for it to apply to)")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-// https://github.com/cue-labs/oci/pull/27
-replace cuelabs.dev/go/oci/ociregistry => github.com/tianon/cuelabs-oci/ociregistry v0.0.0-20240216044210-8aa0c990bd77
+// https://github.com/cue-labs/oci/pull/29
+replace cuelabs.dev/go/oci/ociregistry => github.com/tianon/cuelabs-oci/ociregistry v0.0.0-20240322151419-7d3242933116

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tianon/cuelabs-oci/ociregistry v0.0.0-20240216044210-8aa0c990bd77 h1:9EPZm+sGlYHo6LleMXWR6s3P8SJEYA7/aovpJ76JSpw=
-github.com/tianon/cuelabs-oci/ociregistry v0.0.0-20240216044210-8aa0c990bd77/go.mod h1:ApHceQLLwcOkCEXM1+DyCXTHEJhNGDpJ2kmV6axsx24=
+github.com/tianon/cuelabs-oci/ociregistry v0.0.0-20240322151419-7d3242933116 h1:ZDy4uRAhzODJXRo4EoNpJTCiSeOs8wwrkfMJy3JyDps=
+github.com/tianon/cuelabs-oci/ociregistry v0.0.0-20240322151419-7d3242933116/go.mod h1:pK23AUVXuNzzTpfMCA06sxZGeVQ/75FdVtW249de9Uo=
 golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/registry/client.go
+++ b/registry/client.go
@@ -25,17 +25,23 @@ func Client(host string, opts *ociclient.Options) (ociregistry.Interface, error)
 		if opts != nil {
 			clientOptions = *opts
 		}
-		if clientOptions.HTTPClient == nil {
-			clientOptions.HTTPClient = http.DefaultClient
+		if clientOptions.Transport == nil {
+			clientOptions.Transport = http.DefaultTransport
 		}
 
 		// if we have a rate limiter configured for this registry, shim it in
 		if limiter, ok := registryRateLimiters[host]; ok {
-			clientOptions.HTTPClient = &rateLimitedRetryingDoer{
-				doer:    clientOptions.HTTPClient,
-				limiter: limiter,
+			clientOptions.Transport = &rateLimitedRetryingRoundTripper{
+				roundTripper: clientOptions.Transport,
+				limiter:      limiter,
 			}
 		}
+
+		// install the "authorization" wrapper/shim
+		clientOptions.Transport = ociauth.NewStdTransport(ociauth.StdTransportParams{
+			Config:    authConfig,
+			Transport: clientOptions.Transport,
+		})
 
 		connectHost := host
 		if host == dockerHubCanonical {
@@ -44,14 +50,6 @@ func Client(host string, opts *ociclient.Options) (ociregistry.Interface, error)
 			// assume localhost means HTTP
 			clientOptions.Insecure = true
 			// TODO some way for callers to specify that their "localhost" *does* require TLS (maybe only do this if `opts == nil`, but then users cannot supply *any* options and still get help setting Insecure for localhost 🤔 -- at least this is a more narrow use case than the opposite of not having a way to have non-localhost insecure registries)
-		}
-
-		if clientOptions.Authorizer == nil {
-			// TODO https://github.com/cue-labs/oci/pull/28 -- ideally we'd set this sooner, but https://github.com/cue-labs/oci/blob/5ebe80b0a9a67ae83802d1fb1a189a8f0d089fb0/ociregistry/ociclient/client.go#L278-L282 means we have to do it late in case we installed a rate limiting HTTPClient (or the caller provided a custom one)
-			clientOptions.Authorizer = ociauth.NewStdAuthorizer(ociauth.StdAuthorizerParams{
-				Config:     authConfig,
-				HTTPClient: clientOptions.HTTPClient,
-			})
 		}
 
 		hostOptions := clientOptions // make a copy, since "ociclient.New" mutates it (such that sharing the object afterwards probably isn't the best idea -- they'll have the same DebugID if so, which isn't ideal)
@@ -86,7 +84,7 @@ func Client(host string, opts *ociclient.Options) (ociregistry.Interface, error)
 				default:
 					return nil, fmt.Errorf("unsupported DOCKERHUB_PUBLIC_PROXY (with path)")
 				}
-				// TODO complain about other URL bits (unsupported by "ociclient" except via custom "HTTPClient" / "HTTPDoer")
+				// TODO complain about other URL bits (unsupported by "ociclient" except via custom "RoundTripper")
 			} else if proxy := os.Getenv("DOCKERHUB_PUBLIC_PROXY_HOST"); proxy != "" {
 				proxyHost = proxy
 			}

--- a/registry/lookup.go
+++ b/registry/lookup.go
@@ -1,0 +1,99 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"cuelabs.dev/go/oci/ociregistry"
+	"cuelabs.dev/go/oci/ociregistry/ocimem"
+)
+
+// see `LookupType*` consts for possible values for this type
+type LookupType string
+
+const (
+	LookupTypeManifest LookupType = "manifest"
+	LookupTypeBlob     LookupType = "blob"
+)
+
+type LookupOptions struct {
+	// unspecified implies [LookupTypeManifest]
+	Type LookupType
+
+	// whether or not to do a HEAD instead of a GET (will still return an [ociregistry.BlobReader], but with an empty body / zero bytes)
+	Head bool
+}
+
+// a wrapper around [ociregistry.Interface.GetManifest] (and `GetTag`, `GetBlob`, and the `Resolve*` versions of the above) that accepts a [Reference] and always returns a [ociregistry.BlobReader] (in the case of a HEAD request, it will be a zero-length reader with just a valid descriptor)
+func Lookup(ctx context.Context, ref Reference, opts *LookupOptions) (ociregistry.BlobReader, error) {
+	client, err := Client(ref.Host, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed getting client: %w", ref, err)
+	}
+
+	var o LookupOptions
+	if opts != nil {
+		o = *opts
+	}
+
+	var (
+		r    ociregistry.BlobReader
+		desc ociregistry.Descriptor
+	)
+	switch o.Type {
+	case LookupTypeManifest, "":
+		if ref.Digest != "" {
+			if o.Head {
+				desc, err = client.ResolveManifest(ctx, ref.Repository, ref.Digest)
+			} else {
+				r, err = client.GetManifest(ctx, ref.Repository, ref.Digest)
+			}
+		} else {
+			tag := ref.Tag
+			if tag == "" {
+				tag = "latest"
+			}
+			if o.Head {
+				desc, err = client.ResolveTag(ctx, ref.Repository, tag)
+			} else {
+				r, err = client.GetTag(ctx, ref.Repository, tag)
+			}
+		}
+
+	case LookupTypeBlob:
+		// TODO error if Digest == "" ? (ociclient already does for us, so we can probably just pass it through here without much worry)
+		if o.Head {
+			desc, err = client.ResolveBlob(ctx, ref.Repository, ref.Digest)
+		} else {
+			r, err = client.GetBlob(ctx, ref.Repository, ref.Digest)
+		}
+
+	default:
+		return nil, fmt.Errorf("unknown LookupType: %q", o.Type)
+	}
+
+	// normalize 404 and 404-like to nil return (so it's easier to detect)
+	if err != nil {
+		if errors.Is(err, ociregistry.ErrBlobUnknown) ||
+			errors.Is(err, ociregistry.ErrManifestUnknown) ||
+			errors.Is(err, ociregistry.ErrNameUnknown) {
+			// obvious 404 cases
+			return nil, nil
+		}
+		// https://github.com/cue-labs/oci/issues/26
+		if errStr := strings.TrimPrefix(err.Error(), "error response: "); strings.HasPrefix(errStr, "404 ") ||
+			// 401 often means "repository not found" (due to the nature of public/private mixing on Hub and the fact that ociauth definitely handled any possible authentication for us, so if we're still getting 401 it's unavoidable and might as well be 404)
+			strings.HasPrefix(errStr, "401 ") {
+			return nil, nil
+		}
+		return r, err
+	}
+
+	if o.Head {
+		r = ocimem.NewBytesReader(nil, desc)
+	}
+
+	return r, err
+}

--- a/registry/read-helpers.go
+++ b/registry/read-helpers.go
@@ -20,6 +20,8 @@ func readJSONHelper(r ociregistry.BlobReader, v interface{}) error {
 		return err
 	}
 
+	// TODO if desc.Data != nil and len() == desc.Size, we should probably check/use that? 👀
+
 	// make sure we can't possibly read (much) more than we're supposed to
 	limited := &io.LimitedReader{
 		R: r,


### PR DESCRIPTION
This allows us to store full descriptors (necessary to implement `Resolve*`), but with a net decrease in the number of fields we have to juggle / keep in sync.

This does mean consumers need to be careful about how they use the `Descriptor` objects we return (esp. WRT `Data`), but it makes it easier for them to then have `Data` available if they want it (which is something I'd like to use in the future).  This is a net win anyhow because the upstream objects might've contained `Data` fields so this forces us to deal with them in a sane way we're comfortable with instead of potentially just including them verbatim unintentionally. 🚀

Also: Implement `Resolve{Manifest,Tag,Blob}` in our registry cache

Now that we have `Descriptor` objects (and a way to cache them), this implementation is trivial. 🎉