### PR TITLE
Fix the cache broken by the ociref changes

### DIFF
--- a/cmd/builds/main.go
+++ b/cmd/builds/main.go
@@ -171,7 +171,7 @@ func loadCacheFromFile() error {
 
 	for img, index := range cache.Indexes {
 		index := index // https://github.com/golang/go/issues/60078
-		fun, _ := cacheResolve.LoadOrStore(img, sync.OnceValues(func() (*ocispec.Index, error) {
+		fun, _ := cacheResolve.LoadOrStore(img.String(), sync.OnceValues(func() (*ocispec.Index, error) {
 			return index, nil
 		}))
 		index2, err := fun.(func() (*ocispec.Index, error))()


### PR DESCRIPTION
This was broken by #32 :innocent:

One part of the code was storing keys in our `sync.Map` as a `string` and the other as a `Reference` so they never matched. 😭

If `sync.Map` had been written in the brave new world of Go generics, we'd have a compilation error to help us catch this. 🤦

We *could* get clever with something like a `--network=none` container that forces `builds` to use the cache, but it's a bit complex to set up correctly (so instead I think we should wait for the eventual `sync/v2` upstream Go package or fork/write/switch to a separate "generic" / type-safe `sync.Map` package in the future).

See also https://github.com/golang/go/issues/47657, https://github.com/golang/go/discussions/48287

![image](https://github.com/docker-library/meta-scripts/assets/161631/bd6b5824-e95b-4067-9384-08b89908a2d0)

:innocent: