### PR TITLE
Update `.go-env.sh` for riscv64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/docker-library/meta-scripts
 
+// ideally this would be the single source of truth for this entire repository, but riscv64 means this bleeds into .go-env.sh too -- if changing this, see that file too
 go 1.21
 
 require (


### PR DESCRIPTION
Comments inline, but the short version is that riscv64 being unsupported in stable distros makes life a little hard here (https://github.com/docker-library/golang/issues/435), so we need to build from source based on Debian Unstable as the shortest path to success.