### PR TITLE
Add more "defense in depth" to collecting manifests for deploy

### DIFF
--- a/deploy.jq
+++ b/deploy.jq
@@ -8,7 +8,12 @@ def tagged_manifests(builds_selector; tags_extractor):
 			$i
 			| tags_extractor
 			| ..|strings # no matter what "tags_extractor" gives us, this will flatten us to a stream of strings
-		] += $i.build.resolved.manifests
+		] += [
+			# as an extra protection against cross-architecture "bleeding" ("riscv64" infra pushing "amd64" images, for example), filter the list of manifests to those whose architecture matches the architecture it is supposed to be for
+			# to be explicitly clear, this filtering is *also* done as part of our "builds.json" generation, so this is an added layer of best-effort protection that will be especially important to preserve and/or replicate if/when we solve the "not built yet so include the previous contents of the tag" portion of the problem at this layer instead of in the currently-separate put-shared process
+			$i.build.resolved.manifests[]
+			| select(.annotations["com.docker.official-images.bashbrew.arch"] // "" == $i.build.arch) # this assumes "registry.SynthesizeIndex" created this list of manifests (because it sets this annotation), but it would be reasonable for us to reimplement that conversion of "OCI platform object" to "bashbrew architecture" in pure jq if it was prudent or necessary to do so
+		]
 	)
 ;
 def arch_tagged_manifests($arch):


### PR DESCRIPTION
This replicates some protective code we have in Go as well *and* that we currently use aggressive ACLs on Docker Hub (in two different places!) to help protect against.

The end-goal here is to increase Tianon's confidence that we're sufficiently covering the use case of this defensive measure such that we could adjust "deploy" to run on *one* architecture/infra (for deploying to all arch-specific namespaces) instead of running it on *every* architecture, which does have rate limit implications but otherwise simplifies a lot of things (see recent changes adding hacks on hacks to get deploy working on Windows and riscv64 for examples).