### PR TITLE
Disable BuildKit's new linting functionality (pre-emptively)

### DIFF
--- a/.test/meta-commands/out.sh
+++ b/.test/meta-commands/out.sh
@@ -37,6 +37,7 @@ SOURCE_DATE_EPOCH=1700741054 \
 	--platform 'linux/amd64' \
 	--build-context 'alpine:3.18=docker-image://alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0' \
 	--build-arg BUILDKIT_SYNTAX="$BASHBREW_BUILDKIT_SYNTAX" \
+	--build-arg BUILDKIT_DOCKERFILE_CHECK=skip=all \
 	--file 'Dockerfile' \
 	'https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli'
 mkdir temp

--- a/meta.jq
+++ b/meta.jq
@@ -197,6 +197,7 @@ def build_command:
 						| "--build-context " + @sh
 					),
 					"--build-arg BUILDKIT_SYNTAX=\"$BASHBREW_BUILDKIT_SYNTAX\"", # TODO .doi/.bin/bashbrew-buildkit-env-setup.sh
+					"--build-arg BUILDKIT_DOCKERFILE_CHECK=skip=all", # disable linting (https://github.com/moby/buildkit/pull/4962)
 					@sh "--file \(.source.entry.File)",
 					($buildUrl | @sh),
 					empty


### PR DESCRIPTION
I'm not sold on this behavior in general (or the default-provided checks), but image build time is definitely not the place for them (if we were to do something with them, the appropriate place would be a CI check during image/`Dockerfile` review time).

See https://github.com/moby/buildkit/pull/4962
(I _think_ I'm reading the tests/implementation here correctly that this build arg will override everything including errors specified in the `Dockerfile` itself :crossed_fingers:)