### PR TITLE
Attempt to speed up deploy

### DIFF
--- a/registry/push.go
+++ b/registry/push.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	// if a manifest or blob is more than this many bytes, we'll do a pre-flight HEAD request to verify whether we need to even bother pushing it before we do so (65535 is the theoretical maximum size of a single TCP packet, although MTU means it's usually closer to 1448 bytes, but this seemed like a sane place to draw a line to where a second request that might fail is worth our time)
+	// if a blob is more than this many bytes, we'll do a pre-flight HEAD request to verify whether we need to even bother pushing it before we do so (65535 is the theoretical maximum size of a single TCP packet, although MTU means it's usually closer to 1448 bytes, but this seemed like a sane place to draw a line to where a second request that might fail is worth our time)
 	BlobSizeWorthHEAD = int64(65535)
 )
 
@@ -43,18 +43,18 @@ func EnsureManifest(ctx context.Context, ref Reference, manifest json.RawMessage
 		return desc, fmt.Errorf("%s: failed getting client: %w", ref, err)
 	}
 
-	if desc.Size > BlobSizeWorthHEAD {
-		r, err := Lookup(ctx, ref, &LookupOptions{Head: true})
-		if err != nil {
-			return desc, fmt.Errorf("%s: failed HEAD: %w", ref, err)
-		}
-		// TODO if we had some kind of progress interface, this would be a great place for some kind of debug log of head's contents
-		if r != nil {
-			head := r.Descriptor()
-			r.Close()
-			if head.Digest == desc.Digest && head.Size == desc.Size {
-				return head, nil
-			}
+	// try HEAD request before pushing
+	// if it matches, then we can assume child objects exist as well
+	r, err := Lookup(ctx, ref, &LookupOptions{Head: true})
+	if err != nil {
+		return desc, fmt.Errorf("%s: failed HEAD: %w", ref, err)
+	}
+	// TODO if we had some kind of progress interface, this would be a great place for some kind of debug log of head's contents
+	if r != nil {
+		head := r.Descriptor()
+		r.Close()
+		if head.Digest == desc.Digest && head.Size == desc.Size {
+			return head, nil
 		}
 	}
 


### PR DESCRIPTION
Now that we have rate limits under control, we should always try a HEAD request on the indexes & manifests before the PUT request (since the PUT is much slower).

Some local testing for `riscv64`, `arm32v6`, and `s390x` using https://github.com/docker-library/meta/commit/6c3188a828643e981b2d1c37cf3851ed9ec2b4b0 shows some significant speed increases. I chose these arches since they were fully pushed and would only do head requests (and my Docker Hub user doesn't have access to push to the arch namespaces anyway).
```console
$ jq -L ../meta-scripts/ 'include "deploy"; arch_tagged_manifests("riscv64") | deploy_objects[]' builds.json > deploy.json
$ time ../meta-scripts/bin/deploy < deploy.json
...
real    0m6.736s
user    0m0.065s
sys     0m0.032s
$ # compared to Jenkins: ~ 2min 49s - 4min 49s

$ jq -L ../meta-scripts/ 'include "deploy"; arch_tagged_manifests("arm32v6") | deploy_objects[]' builds.json > deploy.json
$ time ../meta-scripts/bin/deploy < deploy.json
...
real    0m32.444s
user    0m0.053s
sys     0m0.035s
$ # compared to Jenkins: ~ 5min 16s - 8min 58s

$ jq -L ../meta-scripts/ 'include "deploy"; arch_tagged_manifests("s390x") | deploy_objects[]' builds.json > deploy.json
$ time ../meta-scripts/bin/deploy < deploy.json
...
real    3m12.348s
user    0m0.278s
sys     0m0.252s
$ # compared to Jenkins: ~ 19min 36s - 24min 22s
```