### PR TITLE
Ensure our pre-flight HEAD request is always by-tag if we're pushing a tag

### DIFF
--- a/registry/push.go
+++ b/registry/push.go
@@ -45,7 +45,12 @@ func EnsureManifest(ctx context.Context, ref Reference, manifest json.RawMessage
 
 	// try HEAD request before pushing
 	// if it matches, then we can assume child objects exist as well
-	r, err := Lookup(ctx, ref, &LookupOptions{Head: true})
+	headRef := ref
+	if headRef.Tag != "" {
+		// if this function is called with *both* tag *and* digest, the code below works correctly and pushes by tag and then validates by digest, but this lookup specifically will prefer the digest instead and skip when it shouldn't
+		headRef.Digest = ""
+	}
+	r, err := Lookup(ctx, headRef, &LookupOptions{Head: true})
 	if err != nil {
 		return desc, fmt.Errorf("%s: failed HEAD: %w", ref, err)
 	}


### PR DESCRIPTION
This is a latent bug the system has had for large manifests that we now have for all manifests instead! 😄

(This also would artificially inflate our speedups since all the pre-flight HEAD requests would be by-digest which are infinitely cacheable and thus very, very fast.)

Follow-up to #56