### PR TITLE
Specify the builder id for provenance

### DIFF
--- a/.test/meta-commands/out.sh
+++ b/.test/meta-commands/out.sh
@@ -5,7 +5,7 @@
 # <build>
 SOURCE_DATE_EPOCH=1700741054 \
 	docker buildx build --progress=plain \
-	--provenance=mode=max \
+	--provenance=mode=max,builder-id='https://github.com/docker-library' \
 	--output '"type=oci","dest=temp.tar"' \
 	--annotation 'org.opencontainers.image.source=https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli' \
 	--annotation 'org.opencontainers.image.revision=6d541d27b5dd12639e5a33a675ebca04d3837d74' \

--- a/doi.jq
+++ b/doi.jq
@@ -157,6 +157,12 @@ def _sbom_subset:
 	]
 ;
 
+# https://github.com/docker-library/meta-scripts/pull/61 (for lack of better documentation for setting this in buildkit)
+# https://slsa.dev/provenance/v0.2#builder.id
+def buildkit_provenance_builder_id:
+	"https://github.com/docker-library"
+;
+
 # input: "build" object (with "buildId" top level key)
 # output: boolean
 def build_should_sbom:

--- a/meta.jq
+++ b/meta.jq
@@ -139,7 +139,7 @@ def build_command:
 					@sh "SOURCE_DATE_EPOCH=\(.source.entry.SOURCE_DATE_EPOCH)",
 					# TODO EXPERIMENTAL_BUILDKIT_SOURCE_POLICY=<(jq ...)
 					"docker buildx build --progress=plain",
-					"--provenance=mode=max",
+					@sh "--provenance=mode=max,builder-id=\(buildkit_provenance_builder_id)",
 					if build_should_sbom then
 						# see "bashbrew remote arches docker/scout-sbom-indexer:1" (we need the SBOM scanner to be runnable on the host architecture)
 						# bashbrew remote arches --json docker/scout-sbom-indexer:1 | jq '.arches | keys_unsorted' -c


### PR DESCRIPTION
When generating a provenance using the [GitHub Action Build-Push Action](https://github.com/docker/build-push-action) the action sets the builder id as the URL for the current build. This replicates this behavior.

Example
https://oci.dag.dev/?blob=docker/image-signer-verifier@sha256:56e95d5cbc3afae22c0023f0e386cd04254de1ecd6b98b0b1da483b2a28b1c73&mt=application%2Fvnd.in-toto%2Bjson&size=11949

```json
"builder": {
  "id": "https://github.com/docker/image-signer-verifier/actions/runs/9620065389/attempts/1"
},
```

We are wondering however if the GitHub Action run url is the best value to use of if a different URL would be better suited.