### PR TITLE
Fix `docker pull` and `--build-context` to reference correct arch-specific parent manifest

### DIFF
--- a/.test/meta-commands/out.sh
+++ b/.test/meta-commands/out.sh
@@ -35,7 +35,7 @@ SOURCE_DATE_EPOCH=1700741054 \
 	--tag 'amd64/docker:24.0.7-cli-alpine3.18' \
 	--tag 'oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43' \
 	--platform 'linux/amd64' \
-	--build-context 'alpine:3.18=docker-image://alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0' \
+	--build-context 'alpine:3.18=docker-image://alpine@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389' \
 	--build-arg BUILDKIT_SYNTAX="$BASHBREW_BUILDKIT_SYNTAX" \
 	--build-arg BUILDKIT_DOCKERFILE_CHECK=skip=all \
 	--file 'Dockerfile' \
@@ -61,8 +61,8 @@ rm -rf temp
 
 # docker:24.0.7-windowsservercore-ltsc2022 [windows-amd64]
 # <pull>
-docker pull 'mcr.microsoft.com/windows/servercore@sha256:308ef3f8ee3e9c9a1bdec460009c1e6394b329db13eb3149461f8841be5b538a'
-docker tag 'mcr.microsoft.com/windows/servercore@sha256:308ef3f8ee3e9c9a1bdec460009c1e6394b329db13eb3149461f8841be5b538a' 'mcr.microsoft.com/windows/servercore:ltsc2022'
+docker pull 'mcr.microsoft.com/windows/servercore@sha256:d4ab2dd7d3d0fce6edc5df459565a4c96bbb1d0148065b215ab5ddcab1e42eb4'
+docker tag 'mcr.microsoft.com/windows/servercore@sha256:d4ab2dd7d3d0fce6edc5df459565a4c96bbb1d0148065b215ab5ddcab1e42eb4' 'mcr.microsoft.com/windows/servercore:ltsc2022'
 # </pull>
 # <build>
 SOURCE_DATE_EPOCH=1700741054 \

--- a/meta.jq
+++ b/meta.jq
@@ -36,7 +36,9 @@ def pull_command:
 				.build.resolvedParents
 				| to_entries[]
 				| (
-					.value.annotations["org.opencontainers.image.ref.name"] // error("parent \(.key) missing ref")
+					.value.manifests[0].annotations["org.opencontainers.image.ref.name"]
+					// .value.annotations["org.opencontainers.image.ref.name"]
+					// error("parent \(.key) missing ref")
 					| normalize_ref_to_docker
 				) as $ref
 				| @sh "docker pull \($ref)",
@@ -191,7 +193,9 @@ def build_command:
 						.build.resolvedParents
 						| to_entries[]
 						| .key + "=docker-image://" + (
-							.value.annotations["org.opencontainers.image.ref.name"] // error("parent \(.key) missing ref")
+							.value.manifests[0].annotations["org.opencontainers.image.ref.name"]
+							// .value.annotations["org.opencontainers.image.ref.name"]
+							// error("parent \(.key) missing ref")
 							| normalize_ref_to_docker
 						)
 						| "--build-context " + @sh


### PR DESCRIPTION
This avoids trusting Docker and BuildKit to select the "correct" base image (ie, the one we're referencing in our annotations).