### PR TITLE
Set rewrite-timestamp=true

### DIFF
--- a/.test/meta-commands/out.sh
+++ b/.test/meta-commands/out.sh
@@ -6,7 +6,7 @@
 SOURCE_DATE_EPOCH=1700741054 \
 	docker buildx build --progress=plain \
 	--provenance=mode=max,builder-id='https://github.com/docker-library' \
-	--output '"type=oci","dest=temp.tar"' \
+	--output '"type=oci","dest=temp.tar","rewrite-timestamp=true"' \
 	--annotation 'org.opencontainers.image.source=https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/cli' \
 	--annotation 'org.opencontainers.image.revision=6d541d27b5dd12639e5a33a675ebca04d3837d74' \
 	--annotation 'org.opencontainers.image.created=2023-11-23T12:04:14Z' \

--- a/helpers/oci-sbom.sh
+++ b/helpers/oci-sbom.sh
@@ -76,7 +76,7 @@ args=(
 	--load=false --provenance=false # explicitly disable a few features we want to avoid
 	--build-arg BUILDKIT_DOCKERFILE_CHECK=skip=all # disable linting (https://github.com/moby/buildkit/pull/4962)
 	--sbom=generator="$BASHBREW_BUILDKIT_SBOM_GENERATOR"
-	--output "type=oci,tar=false,dest=."
+	--output "type=oci,tar=false,dest=.,rewrite-timestamps=true"
 	# TODO also add appropriate "--tag" lines (which would give us a mostly correct "subject" block in the generated SBOM, but we'd then need to replace instances of $sbomImageManifest with $imageManifest for their values to be correct)
 	--platform "$platform"
 	--build-context "fake=oci-layout://$input@$imageManifest"

--- a/meta.jq
+++ b/meta.jq
@@ -149,6 +149,7 @@ def build_command:
 						[
 							"type=oci",
 							"dest=temp.tar",
+							"rewrite-timestamp=true",
 							empty
 						]
 						| @csv


### PR DESCRIPTION
Part of:
- docker-library/official-images#16044

This exporter option rewrites the timestamps of the files inside image layers to use $SOURCE_DATE_EPOCH so as to increase reproducibility.

https://github.com/moby/buildkit/blob/v0.15.2/docs/build-repro.md#source_date_epoch