### PR TITLE
feat: add provenance.jq

### DIFF
--- a/.test/provenance/in.json
+++ b/.test/provenance/in.json
@@ -1,0 +1,1 @@
+../builds.json

--- a/.test/provenance/out.json
+++ b/.test/provenance/out.json
@@ -1,0 +1,271 @@
+[
+	{
+		"_type": "https://in-toto.io/Statement/v1",
+		"subject": [
+			{
+				"name": "pkg:docker/docker:24.0.7-cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24.0-cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24-cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24.0.7-cli-alpine3.18?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/amd64/docker:24.0.7-cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/amd64/docker:24.0-cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/amd64/docker:24-cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/amd64/docker:cli?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/amd64/docker:24.0.7-cli-alpine3.18?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			},
+			{
+				"name": "pkg:docker/oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43?platform=linux%2Famd64",
+				"digest": {
+					"sha256": "153793dfbac130679ad1eebd9e88b3772c47d3903a3f299c49d5c3f23a6e35d2"
+				}
+			}
+		],
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"predicate": {
+			"buildDefinition": {
+				"buildType": "https://actions.github.io/buildtypes/workflow/v1",
+				"externalParameters": {
+					"workflow": {
+						"ref": "refs/heads/subset",
+						"repository": "https://github.com/docker-library/meta",
+						"path": ".github/workflows/build.yml",
+						"digest": {
+							"gitCommit": "0123456789abcdef0123456789abcdef01234567"
+						}
+					},
+					"inputs": {
+						"buildId": "4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43",
+						"bashbrewArch": "amd64",
+						"firstTag": "docker:24.0.7-cli"
+					}
+				},
+				"internalParameters": {
+					"github": {
+						"event_name": "workflow_dispatch",
+						"repository_id": "1234",
+						"repository_owner_id": "5678",
+						"runner_environment": "github-hosted"
+					}
+				},
+				"resolvedDependencies": [
+					{
+						"uri": "git+https://github.com/docker-library/meta@refs/heads/subset",
+						"digest": {
+							"gitCommit": "0123456789abcdef0123456789abcdef01234567"
+						}
+					}
+				]
+			},
+			"runDetails": {
+				"builder": {
+					"id": "https://github.com/docker-library/meta/.github/workflows/build.yml@refs/heads/subset"
+				},
+				"metadata": {
+					"invocationId": "https://github.com/docker-library/meta/actions/runs/9001/attempts/2"
+				}
+			}
+		}
+	},
+	{
+		"_type": "https://in-toto.io/Statement/v1",
+		"subject": [
+			{
+				"name": "pkg:docker/docker:24.0.7-windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24.0-windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24-windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24.0.7-windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24.0-windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:24-windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/docker:windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:24.0.7-windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:24.0-windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:24-windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:windowsservercore-ltsc2022?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:24.0.7-windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:24.0-windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:24-windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/winamd64/docker:windowsservercore?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			},
+			{
+				"name": "pkg:docker/oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e?platform=windows%2Famd64",
+				"digest": {
+					"sha256": "69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce"
+				}
+			}
+		],
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"predicate": {
+			"buildDefinition": {
+				"buildType": "https://actions.github.io/buildtypes/workflow/v1",
+				"externalParameters": {
+					"workflow": {
+						"ref": "refs/heads/subset",
+						"repository": "https://github.com/docker-library/meta",
+						"path": ".github/workflows/build.yml",
+						"digest": {
+							"gitCommit": "0123456789abcdef0123456789abcdef01234567"
+						}
+					},
+					"inputs": {
+						"buildId": "9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e",
+						"bashbrewArch": "windows-amd64",
+						"firstTag": "docker:24.0.7-windowsservercore-ltsc2022",
+						"windowsVersion": "2022"
+					}
+				},
+				"internalParameters": {
+					"github": {
+						"event_name": "workflow_dispatch",
+						"repository_id": "1234",
+						"repository_owner_id": "5678",
+						"runner_environment": "github-hosted"
+					}
+				},
+				"resolvedDependencies": [
+					{
+						"uri": "git+https://github.com/docker-library/meta@refs/heads/subset",
+						"digest": {
+							"gitCommit": "0123456789abcdef0123456789abcdef01234567"
+						}
+					}
+				]
+			},
+			"runDetails": {
+				"builder": {
+					"id": "https://github.com/docker-library/meta/.github/workflows/build.yml@refs/heads/subset"
+				},
+				"metadata": {
+					"invocationId": "https://github.com/docker-library/meta/actions/runs/9001/attempts/2"
+				}
+			}
+		}
+	}
+]

--- a/.test/provenance/test.jq
+++ b/.test/provenance/test.jq
@@ -24,6 +24,9 @@ include "jenkins";
 		workflow_ref: "docker-library/meta/.github/workflows/build.yml@refs/heads/\($payload.ref)",
 		workflow_sha: "0123456789abcdef0123456789abcdef01234567",
 	} as $github
+	| {
+		environment: "github-hosted",
+	} as $runner
 
-	| github_actions_provenance($github; $digest)
+	| github_actions_provenance($github; $runner; $digest)
 ]

--- a/.test/provenance/test.jq
+++ b/.test/provenance/test.jq
@@ -1,0 +1,29 @@
+include "provenance";
+include "jenkins";
+
+[
+	first(.[] | select(.build.arch == "amd64" and .build.resolved)),
+	first(.[] | select(.build.arch == "windows-amd64" and .build.resolved)),
+	empty # trailing comma
+
+	| (.build.resolved.annotations["org.opencontainers.image.ref.name"] | split("@")[1]) as $digest
+
+	# some faked GitHub event data so we can ~test the provenance generation
+	| gha_payload as $payload
+	| {
+		event: $payload,
+		event_name: "workflow_dispatch",
+		ref: "refs/heads/\($payload.ref)",
+		repository: "docker-library/meta",
+		repository_id: "1234",
+		repository_owner_id: "5678",
+		run_attempt: "2",
+		run_id: "9001",
+		server_url: "https://github.com",
+		sha: "0123456789abcdef0123456789abcdef01234567",
+		workflow_ref: "docker-library/meta/.github/workflows/build.yml@refs/heads/\($payload.ref)",
+		workflow_sha: "0123456789abcdef0123456789abcdef01234567",
+	} as $github
+
+	| github_actions_provenance($github; $digest)
+]

--- a/provenance.jq
+++ b/provenance.jq
@@ -1,77 +1,78 @@
-# input: "build" object (with "buildId" top level key)
-# output: list of image tags
-def tags:
-	[
-		.source.arches[].tags[],
-		.source.arches[].archTags[],
-		.build.img
-	]
-;
-
-# input: "tags" object with image digest and platform arguments
-# output: json object for in-toto provenance subject field
-def subjects($platform; $digest):
-	($digest | split(":")) as $splitDigest
-	| {
-		"name": "pkg:docker/\(.)?platform=\($platform)",
-		"digest": {
-			($splitDigest[0]): $splitDigest[1],
-		}
-	}
-;
-
-# input: GITHUB context
-# output: json object for in-toto provenance external parameters field
-def github_external_parameters($github):
-	($github.workflow_ref | ltrimstr($github.repository + "/") | split("@")) as $workflowRefSplit
-	| {
-		inputs: $github.event.inputs,
-		workflow: {
-			ref: $workflowRefSplit[1],
-			repository: ($github.server_url + "/" + $github.repository),
-			path: $workflowRefSplit[0],
-			digest: { gitCommit: $github.workflow_sha },
-		}
-	}
-;
-
 # input: "build" object with platform and image digest
-# output: json object for in-toto provenance statement
-def github_actions_provenance:
-	(env.GITHUB_CONTEXT | fromjson) as $github |
-	(.source.arches[].platformString | @uri) as $platform |
-	{
-		_type: "https://in-toto.io/Statement/v1",
-		subject: . | tags | map(subjects($platform; $digest)),
-		predicateType: "https://slsa.dev/provenance/v1",
-		predicate: {
-			buildDefinition: {
-				buildType: "https://actions.github.io/buildtypes/workflow/v1",
-				externalParameters: github_external_parameters($github),
-				internalParameters: {
-					github: {
-						event_name: $github.event_name,
-						repository_id: $github.repository_id,
-						repository_owner_id: $github.repository_owner_id,
-						runner_environment: "github-hosted"
-					}
-				},
-				resolvedDependencies: [{
-					uri: ("git+"+$github.server_url+"/"+$github.repository+"@"+$github.ref),
-					digest: { "gitCommit": $github.sha }
-				}]
-			},
-			runDetails: {
-				# builder.id identifies the transitive closure of the trusted build platform evalution.
-				# any changes that alter security properties or build level must update this ID and rotate the signing key.
-				# https://slsa.dev/spec/v1.0/provenance#builder
-				builder: {
-					id: ($github.server_url+"/"+$github.workflow_ref),
-				},
-				metadata: {
-					invocationId: ($github.server_url+"/"+$github.repository+"/actions/runs/"+$github.run_id+"/attempts/"+$github.run_attempt),
+#   $github: "github" context; CONTAINS SENSITIVE INFORMATION (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context)
+#   $digest: the OCI image digest for the just-built image (normally in .build.resolved.annotations["org.opencontainers.image.ref.name"] but only post-push/regeneration and we haven't pushed yet)
+#
+# output: in-toto provenance statement (https://slsa.dev/spec/v1.0/provenance)
+#   see also: https://github.com/actions/buildtypes/tree/main/workflow/v1
+def github_actions_provenance($github; $digest):
+	if $github.event_name != "workflow_dispatch" then error("error: '\($github.event_name)' is not a supported event type for provenance generation") else
+		{
+			_type: "https://in-toto.io/Statement/v1",
+			subject: [
+				($digest | split(":")) as $splitDigest
+				| (.source.arches[.build.arch].platformString) as $platform
+				| (
+					.source.arches[.build.arch].tags[],
+					.source.arches[.build.arch].archTags[],
+					.build.img,
+					empty # trailing comma
+				)
+				| {
+					# https://github.com/package-url/purl-spec/blob/b33dda1cf4515efa8eabbbe8e9b140950805f845/PURL-TYPES.rst#docker (this matches what BuildKit generates as of 2024-09-18; "oci" would also be a reasonable choice, but would require signer and policy changes to support, and be more complex to generate accurately)
+					name: "pkg:docker/\(.)?platform=\($platform | @uri)",
+					digest: { ($splitDigest[0]): $splitDigest[1] },
 				}
-			}
+			],
+			predicateType: "https://slsa.dev/provenance/v1",
+			predicate: {
+				buildDefinition: {
+					buildType: "https://actions.github.io/buildtypes/workflow/v1",
+					externalParameters: {
+						workflow: {
+							# TODO this matches how this is documented/suggested in GitHub's buildType documentation, but does not account for the workflow file being in a separate repository at a separate ref from the "source" (which the "workflow_ref" field *does* account for), so that would/will change how we need to calculate these values if we ever do that (something like "^(?<repo>[^/]+/[^/]+)/(?<path>.*)@(?<ref>refs/.*)$" on $github.workflow_ref ?)
+							ref: $github.ref,
+							repository: ($github.server_url + "/" + $github.repository),
+							path: (
+								$github.workflow_ref
+								| ltrimstr($github.repository + "/")
+								| rtrimstr("@" + $github.ref)
+								| if contains("@") then error("parsing 'workflow_ref' failed: '\(.)'") else . end
+							),
+							# not required, but useful/important (and potentially but unlikely different from $github.sha used in resolvedDependencies below):
+							digest: { gitCommit: $github.workflow_sha },
+						},
+						inputs: $github.event.inputs, # https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_dispatch
+					},
+					internalParameters: {
+						github: {
+							event_name: $github.event_name,
+							repository_id: $github.repository_id,
+							repository_owner_id: $github.repository_owner_id,
+							runner_environment: "github-hosted",
+						},
+					},
+					resolvedDependencies: [
+						{
+							uri: "git+\($github.server_url)/\($github.repository)@\($github.ref)",
+							digest: { "gitCommit": $github.sha },
+						},
+						# TODO figure out a way to include resolved action SHAs from "uses:" expressions
+						# TODO include more resolved dependencies
+						empty # tailing comma
+					],
+				},
+				runDetails: {
+					# builder.id identifies the transitive closure of the trusted build platform evalution.
+					# any changes that alter security properties or build level must update this ID and rotate the signing key.
+					# https://slsa.dev/spec/v1.0/provenance#builder
+					builder: {
+						id: ($github.server_url + "/" + $github.workflow_ref),
+					},
+					metadata: {
+						invocationId: "\($github.server_url)/\($github.repository)/actions/runs/\($github.run_id)/attempts/\($github.run_attempt)",
+					},
+				},
+			},
 		}
-	}
+	end
 ;

--- a/provenance.jq
+++ b/provenance.jq
@@ -1,10 +1,11 @@
 # input: "build" object with platform and image digest
 #   $github: "github" context; CONTAINS SENSITIVE INFORMATION (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context)
+#   $runner: "runner" context; https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context
 #   $digest: the OCI image digest for the just-built image (normally in .build.resolved.annotations["org.opencontainers.image.ref.name"] but only post-push/regeneration and we haven't pushed yet)
 #
 # output: in-toto provenance statement (https://slsa.dev/spec/v1.0/provenance)
 #   see also: https://github.com/actions/buildtypes/tree/main/workflow/v1
-def github_actions_provenance($github; $digest):
+def github_actions_provenance($github; $runner; $digest):
 	if $github.event_name != "workflow_dispatch" then error("error: '\($github.event_name)' is not a supported event type for provenance generation") else
 		{
 			_type: "https://in-toto.io/Statement/v1",
@@ -48,7 +49,7 @@ def github_actions_provenance($github; $digest):
 							event_name: $github.event_name,
 							repository_id: $github.repository_id,
 							repository_owner_id: $github.repository_owner_id,
-							runner_environment: "github-hosted",
+							runner_environment: $runner.environment,
 						},
 					},
 					resolvedDependencies: [

--- a/provenance.jq
+++ b/provenance.jq
@@ -70,7 +70,7 @@ def github_actions_provenance($github; $runner; $digest):
 						id: ($github.server_url + "/" + $github.workflow_ref),
 					},
 					metadata: {
-						invocationId: "\($github.server_url)/\($github.repository)/actions/runs/\($github.run_id)/attempts/\($github.run_attempt)",
+						invocationId: ($github.server_url + "/" + $github.repository + "/actions/runs/" + $github.run_id + "/attempts/" + $github.run_attempt)
 					},
 				},
 			},

--- a/provenance.jq
+++ b/provenance.jq
@@ -1,0 +1,80 @@
+# input: "build" object (with "buildId" top level key)
+# output: array of image tags
+def tags:
+  .source.arches[].tags[],
+  .source.arches[].archTags[],
+  .build.img
+;
+
+# input: "build" object (with "buildId" top level key)
+# output: purl platform query string
+def platform_string:
+  .source.arches[].platformString | gsub("/"; "%2F")
+;
+
+# input: "tags" object with image digest and platform arguments
+# output: json object for in-toto provenance subject field
+def subjects($platform; $digest):
+  {
+      "name": ("pkg:docker/" + . + "?platform=" + $platform),
+      "digest": {
+        "sha256": $digest
+      }
+  }
+;
+
+# input: GITHUB context argument
+# output: json object for in-toto provenance external parameters field
+def github_external_parameters($context):
+($context.workflow_ref | gsub( $context.repository + "/"; "")) as $workflowPathRef |
+{
+  inputs: $context.event.inputs,
+  workflow: {
+    ref: ($workflowPathRef | split("@")[1]),
+    repository: ($context.server_url + "/" + $context.repository),
+    path: ($workflowPathRef | split("@")[0]),
+    digest: {sha256: $context.workflow_sha}
+  }
+}
+;
+
+# input: GITHUB context argument
+# output: json object for in-toto provenance internal parameters field
+def github_internal_parameters($context):
+{
+  github: {
+    event_name: $context.event_name,
+    repository_id: $context.repository_id,
+    repository_owner_id: $context.repository_owner_id,
+  }
+}
+;
+
+# input: "tags" object with platform, image digest and GITHUB context arguments
+# output: json object for in-toto provenance statement
+def github_actions_provenance($platform; $digest; $context):
+{
+  _type: "https://in-toto.io/Statement/v1",
+  subject: . | map(subjects($platform; $digest)),
+  predicateType: "https://slsa.dev/provenance/v1",
+  predicate: {
+        buildDefinition: {
+            buildType: "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
+            externalParameters: github_external_parameters($context),
+            internalParameters: github_internal_parameters($context),
+            resolvedDependencies: [{
+                uri: ("git+"+$context.server_url+"/"+$context.repository+"@"+$context.ref),
+                digest: { "gitCommit": $context.sha }
+            }]
+        },
+        runDetails: {
+            builder: {
+                id: ($context.server_url+"/"+$context.workflow_ref),
+            },
+            metadata: {
+                invocationId: ($context.server_url+"/"+$context.repository+"/actions/runs/"+$context.run_id+"/attempts/"+$context.run_attempt),
+            }
+        }
+    }
+}
+;


### PR DESCRIPTION
## summary
- adds `provenance.jq` filter to generate in-toto provenance for GHA builds

## usage
example usage:
```bash
json="$(
  jq -L.scripts '
    include "meta";
    .[env.BUILD_ID]
    | select(needs_build and .build.arch == env.BASHBREW_ARCH) # sanity check
    | .commands = commands
  ' builds.json
)"

image-digest() {
  local dir="$1"
  local manifest
  manifest="$dir/blobs/$(jq -r '.manifests[0].digest | sub(":"; "/")' "$dir/index.json")" || return "$?"
  jq -L.scripts -r -s '
    include "oci";
    . | image_digest("linux"; env.BASHBREW_ARCH)
  ' $manifest || return "$?"
}
digest=$(image-digest temp)

echo $buildJson | jq -L.scripts --argjson github '${{ env.GITHUB_CONTEXT }}' --argjson runner '${{ toJson(runner) }}' --arg digest ${digest} '
  include "provenance";
  github_actions_provenance($github; $runner; $digest)
' >> provenance.json
```

## output
example output:
```json
{
  "_type": "https://in-toto.io/Statement/v1",
  "subject": [
    {
      "name": "pkg:docker/notary:server-0.7.0?platform=linux%2Famd64",
      "digest": {
        "sha256": "b58c16c79286924b4b96f11061c34498fe137db319aa3e5b606e309f492f2edb"
      }
    },
    {
      "name": "pkg:docker/notary:server?platform=linux%2Famd64",
      "digest": {
        "sha256": "b58c16c79286924b4b96f11061c34498fe137db319aa3e5b606e309f492f2edb"
      }
    },
    {
      "name": "pkg:docker/amd64/notary:server-0.7.0?platform=linux%2Famd64",
      "digest": {
        "sha256": "b58c16c79286924b4b96f11061c34498fe137db319aa3e5b606e309f492f2edb"
      }
    },
    {
      "name": "pkg:docker/amd64/notary:server?platform=linux%2Famd64",
      "digest": {
        "sha256": "b58c16c79286924b4b96f11061c34498fe137db319aa3e5b606e309f492f2edb"
      }
    },
    {
      "name": "pkg:docker/oisupport/staging-amd64:96b43f70bdd4601f5dd42b5525f9818e4b834fde87a0311e28401b4c9a836ff4?platform=linux%2Famd64",
      "digest": {
        "sha256": "b58c16c79286924b4b96f11061c34498fe137db319aa3e5b606e309f492f2edb"
      }
    }
  ],
  "predicateType": "https://slsa.dev/provenance/v1",
  "predicate": {
    "buildDefinition": {
      "buildType": "https://actions.github.io/buildtypes/workflow/v1",
      "externalParameters": {
        "inputs": {
          "bashbrewArch": "amd64",
          "buildId": "96b43f70bdd4601f5dd42b5525f9818e4b834fde87a0311e28401b4c9a836ff4",
          "firstTag": "notary:server-0.7.0"
        },
        "workflow": {
          "ref": "refs/heads/main",
          "repository": "https://github.com/mrjoelkamp/gha-test",
          "path": ".github/workflows/test.yml",
          "digest": {
            "sha256": "11d1f3b6c0efade1b907d0ff3ab41e960787fbf4"
          }
        }
      },
      "internalParameters": {
        "github": {
          "event_name": "workflow_dispatch",
          "repository_id": "712982891",
          "repository_owner_id": "2976326"
        }
      },
      "resolvedDependencies": [
        {
          "uri": "git+https://github.com/mrjoelkamp/gha-test@refs/heads/main",
          "digest": {
            "gitCommit": "11d1f3b6c0efade1b907d0ff3ab41e960787fbf4"
          }
        }
      ]
    },
    "runDetails": {
      "builder": {
        "id": "https://github.com/mrjoelkamp/gha-test/.github/workflows/test.yml@refs/heads/main"
      },
      "metadata": {
        "invocationId": "https://github.com/mrjoelkamp/gha-test/actions/runs/10780651714/attempts/1"
      }
    }
  }
}
```