### PR TITLE
Switch from the `subset` branch back to `main`

### DIFF
--- a/.test/provenance/out.json
+++ b/.test/provenance/out.json
@@ -75,7 +75,7 @@
 				"buildType": "https://actions.github.io/buildtypes/workflow/v1",
 				"externalParameters": {
 					"workflow": {
-						"ref": "refs/heads/subset",
+						"ref": "refs/heads/main",
 						"repository": "https://github.com/docker-library/meta",
 						"path": ".github/workflows/build.yml",
 						"digest": {
@@ -98,7 +98,7 @@
 				},
 				"resolvedDependencies": [
 					{
-						"uri": "git+https://github.com/docker-library/meta@refs/heads/subset",
+						"uri": "git+https://github.com/docker-library/meta@refs/heads/main",
 						"digest": {
 							"gitCommit": "0123456789abcdef0123456789abcdef01234567"
 						}
@@ -107,7 +107,7 @@
 			},
 			"runDetails": {
 				"builder": {
-					"id": "https://github.com/docker-library/meta/.github/workflows/build.yml@refs/heads/subset"
+					"id": "https://github.com/docker-library/meta/.github/workflows/build.yml@refs/heads/main"
 				},
 				"metadata": {
 					"invocationId": "https://github.com/docker-library/meta/actions/runs/9001/attempts/2"
@@ -227,7 +227,7 @@
 				"buildType": "https://actions.github.io/buildtypes/workflow/v1",
 				"externalParameters": {
 					"workflow": {
-						"ref": "refs/heads/subset",
+						"ref": "refs/heads/main",
 						"repository": "https://github.com/docker-library/meta",
 						"path": ".github/workflows/build.yml",
 						"digest": {
@@ -251,7 +251,7 @@
 				},
 				"resolvedDependencies": [
 					{
-						"uri": "git+https://github.com/docker-library/meta@refs/heads/subset",
+						"uri": "git+https://github.com/docker-library/meta@refs/heads/main",
 						"digest": {
 							"gitCommit": "0123456789abcdef0123456789abcdef01234567"
 						}
@@ -260,7 +260,7 @@
 			},
 			"runDetails": {
 				"builder": {
-					"id": "https://github.com/docker-library/meta/.github/workflows/build.yml@refs/heads/subset"
+					"id": "https://github.com/docker-library/meta/.github/workflows/build.yml@refs/heads/main"
 				},
 				"metadata": {
 					"invocationId": "https://github.com/docker-library/meta/actions/runs/9001/attempts/2"

--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -18,7 +18,7 @@ node('multiarch-' + env.BASHBREW_ARCH) { ansiColor('xterm') {
 				url: 'https://github.com/docker-library/meta.git',
 				name: 'origin',
 			]],
-			branches: [[name: '*/subset']], // TODO back to main
+			branches: [[name: '*/main']],
 			extensions: [
 				submodule(
 					parentCredentials: true,

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -23,7 +23,7 @@ node('put-shared') { ansiColor('xterm') {
 				url: 'https://github.com/docker-library/meta.git',
 				name: 'origin',
 			]],
-			branches: [[name: '*/subset']], // TODO back to main
+			branches: [[name: '*/main']],
 			extensions: [
 				submodule(
 					parentCredentials: true,

--- a/Jenkinsfile.meta
+++ b/Jenkinsfile.meta
@@ -15,7 +15,7 @@ node {
 				credentialsId: 'docker-library-bot',
 				name: 'origin',
 			]],
-			branches: [[name: '*/subset']], // TODO back to main
+			branches: [[name: '*/main']],
 			extensions: [
 				submodule(
 					recursiveSubmodules: true,
@@ -101,7 +101,7 @@ node {
 		}
 		sshagent(['docker-library-bot']) {
 			stage('Push') {
-				sh 'git push origin HEAD:subset' // TODO back to main
+				sh 'git push origin HEAD:main'
 			}
 		}
 	}

--- a/Jenkinsfile.trigger
+++ b/Jenkinsfile.trigger
@@ -24,7 +24,7 @@ node {
 				url: 'https://github.com/docker-library/meta.git',
 				name: 'origin',
 			]],
-			branches: [[name: '*/subset']], // TODO back to main
+			branches: [[name: '*/main']],
 			extensions: [
 				submodule(
 					parentCredentials: true,

--- a/jenkins.jq
+++ b/jenkins.jq
@@ -21,7 +21,7 @@ def crane_deploy_commands:
 # output: json object (to trigger the build on GitHub Actions)
 def gha_payload:
 	{
-		ref: "subset", # TODO back to main
+		ref: "main",
 		inputs: (
 			{
 				buildId: .buildId,


### PR DESCRIPTION
When I created these branches ~a year ago, I had lofty goals that we'd be able to turn on "everything" quickly enough that the `subset` branch would be short-lived and that `main` could stay faithfully tracking the "everything is included" world, but the reality is much messier.

In an attempt to be extremely pragmatic about the reality, my intention is to delete the existing (now extremely outdated) `main` branch and simply rename `subset` to `main`.  It will then organically grow to include "everything" as we've been doing (and eventually we'll even ditch `subset.txt` 🤞).