### PR TITLE
Add sbom scanning command

### DIFF
--- a/.test/meta-commands/out.sh
+++ b/.test/meta-commands/out.sh
@@ -53,6 +53,24 @@ jq '
 ' temp/index.json > temp/index.json.new
 mv temp/index.json.new temp/index.json
 # </build>
+# <sbom_scan>
+docker buildx build --progress=plain \
+	--provenance=false \
+	--sbom=generator="$BASHBREW_BUILDKIT_SBOM_GENERATOR" \
+	--tag 'docker:24.0.7-cli' \
+	--tag 'docker:24.0-cli' \
+	--tag 'docker:24-cli' \
+	--tag 'docker:cli' \
+	--tag 'docker:24.0.7-cli-alpine3.18' \
+	--tag 'amd64/docker:24.0.7-cli' \
+	--tag 'amd64/docker:24.0-cli' \
+	--tag 'amd64/docker:24-cli' \
+	--tag 'amd64/docker:cli' \
+	--tag 'amd64/docker:24.0.7-cli-alpine3.18' \
+	--tag 'oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43' \
+	--output '"type=oci","tar=false","dest=sbom"' \
+	- <<<'FROM oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43@sha256:0432a4d379794811b4a2e01d0d3e67a9bcf95d6c2bf71545f03bce3f1d60f401'
+# </sbom_scan>
 # <push>
 crane push temp 'oisupport/staging-amd64:4b199ac326c74b3058a147e14f553af9e8e1659abc29bd3e82c9c9807b66ee43'
 rm -rf temp
@@ -88,6 +106,30 @@ SOURCE_DATE_EPOCH=1700741054 \
 	--file 'Dockerfile' \
 	'https://github.com/docker-library/docker.git#6d541d27b5dd12639e5a33a675ebca04d3837d74:24/windows/windowsservercore-ltsc2022'
 # </build>
+# <sbom_scan>
+docker buildx build --progress=plain \
+	--provenance=false \
+	--sbom=generator="$BASHBREW_BUILDKIT_SBOM_GENERATOR" \
+	--tag 'docker:24.0.7-windowsservercore-ltsc2022' \
+	--tag 'docker:24.0-windowsservercore-ltsc2022' \
+	--tag 'docker:24-windowsservercore-ltsc2022' \
+	--tag 'docker:windowsservercore-ltsc2022' \
+	--tag 'docker:24.0.7-windowsservercore' \
+	--tag 'docker:24.0-windowsservercore' \
+	--tag 'docker:24-windowsservercore' \
+	--tag 'docker:windowsservercore' \
+	--tag 'winamd64/docker:24.0.7-windowsservercore-ltsc2022' \
+	--tag 'winamd64/docker:24.0-windowsservercore-ltsc2022' \
+	--tag 'winamd64/docker:24-windowsservercore-ltsc2022' \
+	--tag 'winamd64/docker:windowsservercore-ltsc2022' \
+	--tag 'winamd64/docker:24.0.7-windowsservercore' \
+	--tag 'winamd64/docker:24.0-windowsservercore' \
+	--tag 'winamd64/docker:24-windowsservercore' \
+	--tag 'winamd64/docker:windowsservercore' \
+	--tag 'oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e' \
+	--output '"type=oci","tar=false","dest=sbom"' \
+	- <<<'FROM oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e@sha256:69aba7120e3f4014bfa80f4eae2cfc9698dcb6b8a5d64daf06de4039a19846ce'
+# </sbom_scan>
 # <push>
 docker push 'oisupport/staging-windows-amd64:9b405cfa5b88ba65121aabdb95ae90fd2e1fee7582174de82ae861613ae3072e'
 # </push>
@@ -174,6 +216,34 @@ done
 jq -r --argjson sbomManifestDesc "$sbomManifestDesc" '.manifests += [ $sbomManifestDesc ]' temp/index.json > temp/index.json.new
 mv temp/index.json.new temp/index.json
 # </build>
+# <sbom_scan>
+docker buildx build --progress=plain \
+	--provenance=false \
+	--sbom=generator="$BASHBREW_BUILDKIT_SBOM_GENERATOR" \
+	--tag 'busybox:1.36.1' \
+	--tag 'busybox:1.36' \
+	--tag 'busybox:1' \
+	--tag 'busybox:stable' \
+	--tag 'busybox:latest' \
+	--tag 'busybox:1.36.1-glibc' \
+	--tag 'busybox:1.36-glibc' \
+	--tag 'busybox:1-glibc' \
+	--tag 'busybox:stable-glibc' \
+	--tag 'busybox:glibc' \
+	--tag 'amd64/busybox:1.36.1' \
+	--tag 'amd64/busybox:1.36' \
+	--tag 'amd64/busybox:1' \
+	--tag 'amd64/busybox:stable' \
+	--tag 'amd64/busybox:latest' \
+	--tag 'amd64/busybox:1.36.1-glibc' \
+	--tag 'amd64/busybox:1.36-glibc' \
+	--tag 'amd64/busybox:1-glibc' \
+	--tag 'amd64/busybox:stable-glibc' \
+	--tag 'amd64/busybox:glibc' \
+	--tag 'oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f' \
+	--output '"type=oci","tar=false","dest=sbom"' \
+	- <<<'FROM oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f@sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0'
+# </sbom_scan>
 # <push>
 crane push --index temp 'oisupport/staging-amd64:191402ad0feacf03daf9d52a492207e73ef08b0bd17265043aea13aa27e2bb3f'
 rm -rf temp


### PR DESCRIPTION
This adds a command to generate SBOM independently of the build which has several advantages:

* Unified approach for generating SBOM across different building methods (buildkit, OCI IMport etc..)
* Adds ability to support more architectures by decoupling the build and the scan architecture
* Ability to fix broken or out of date SBOM without needing to trigger a new build.