### PR TITLE
Double our Docker Hub rate limit

### DIFF
--- a/registry/rate-limits.go
+++ b/registry/rate-limits.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	registryRateLimiters = map[string]*rate.Limiter{
-		dockerHubCanonical: rate.NewLimiter(100/rate.Limit((1*time.Minute).Seconds()), 100), // stick to at most 100/min in registry/Hub requests (and allow an immediate burst of 100)
+		dockerHubCanonical: rate.NewLimiter(200/rate.Limit((1*time.Minute).Seconds()), 200), // stick to at most 200/min in registry/Hub requests (and allow an immediate burst of 200)
 	}
 )
 


### PR DESCRIPTION
This increases our rate limit from 100/min up to 200/min (with an immediate burst of up to 200 and at most 200 at once).  This should be generally safe since the code will already very aggressively drain the pool of available "tokens" the minute it sees a 429 (thus only doing a trickle of requests anyhow), and we auto-retry on 429, but only after a delay of a full second per request.

If all goes well, this should help mitigate our amd64 deploy jobs that have crept back up to a full hour runtime (without adding further parallelization complexity yet).