### PR TITLE
Reorganize Jenkins jobs

### DIFF
--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -8,7 +8,7 @@ properties([
 	]),
 ])
 
-env.BASHBREW_ARCH = env.JOB_NAME.split('/')[-1].minus('build-') // "windows-amd64", "arm64v8", etc
+env.BASHBREW_ARCH = env.JOB_NAME.minus('/build').split('/')[-1] // "windows-amd64", "arm64v8", etc
 env.BUILD_ID = params.buildId
 
 node('multiarch-' + env.BASHBREW_ARCH) { ansiColor('xterm') {

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -9,12 +9,12 @@ properties([
 		userBoost: true,
 	]),
 	pipelineTriggers([
-		upstream('meta'),
+		upstream('../meta'),
 		cron('H H/6 * * *'), // run every few hours whether we "need" it or not
 	]),
 ])
 
-env.BASHBREW_ARCH = env.JOB_NAME.split('/')[-1].minus('deploy-') // "windows-amd64", "arm64v8", etc
+env.BASHBREW_ARCH = env.JOB_NAME.minus('/deploy').split('/')[-1] // "windows-amd64", "arm64v8", etc
 
 node('put-shared') { ansiColor('xterm') {
 	stage('Checkout') {


### PR DESCRIPTION
Closes https://github.com/docker-library/meta-scripts/issues/94 (see that description for more details)

Before:

```
multiarch/ARCH/REPO (old, disabled)

wip/new/meta
wip/new/trigger-gha
wip/new/trigger-ARCH
wip/new/build-ARCH
wip/new/deploy-ARCH
```

After: ("the meta build system")

```
multiarch/ARCH/REPO (old, disabled, could be removed)

meta/meta
meta/ARCH/trigger
meta/ARCH/build
meta/ARCH/deploy
```

As a matter of process, we probably want to disable the jobs first, then merge this, then move them, then re-enable them (likely `meta` first so the submodule gets updated before we start running other jobs).