### PR TITLE
Update Jenkinsfile.* to use shallow clones of meta

### DIFF
--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -20,6 +20,11 @@ node('multiarch-' + env.BASHBREW_ARCH) { ansiColor('xterm') {
 			]],
 			branches: [[name: '*/main']],
 			extensions: [
+				cloneOption(
+					noTags: true,
+					shallow: true,
+					depth: 1,
+				),
 				submodule(
 					parentCredentials: true,
 					recursiveSubmodules: true,

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -25,6 +25,11 @@ node('put-shared') { ansiColor('xterm') {
 			]],
 			branches: [[name: '*/main']],
 			extensions: [
+				cloneOption(
+					noTags: true,
+					shallow: true,
+					depth: 1,
+				),
 				submodule(
 					parentCredentials: true,
 					recursiveSubmodules: true,

--- a/Jenkinsfile.meta
+++ b/Jenkinsfile.meta
@@ -17,6 +17,11 @@ node {
 			]],
 			branches: [[name: '*/main']],
 			extensions: [
+				cloneOption(
+					noTags: true,
+					shallow: true,
+					depth: 1,
+				),
 				submodule(
 					recursiveSubmodules: true,
 					parentCredentials: true,

--- a/Jenkinsfile.trigger
+++ b/Jenkinsfile.trigger
@@ -26,6 +26,11 @@ node {
 			]],
 			branches: [[name: '*/main']],
 			extensions: [
+				cloneOption(
+					noTags: true,
+					shallow: true,
+					depth: 1,
+				),
 				submodule(
 					parentCredentials: true,
 					recursiveSubmodules: true,


### PR DESCRIPTION
We don't need a full (unshallow) clone for any of these -- the jobs don't look at the commit history and we can make new commits without having history locally.

This will help on architectures that have been struggling to clone the repository since the move (because a "full" clone is now bigger than it was when we started all this), but is also generally better all around.

(I've tested this successfully on `mips64le`'s failing `build` job: https://doi-janky.infosiftr.net/job/meta/job/mips64le/job/build/10430/console)