### PR TITLE
Save firstTime this build was attempted in past-jobs.json

### DIFF
--- a/Jenkinsfile.trigger
+++ b/Jenkinsfile.trigger
@@ -52,10 +52,7 @@ node {
 					! wget --timeout=5 -qO past-jobs.json "$JOB_URL/lastSuccessfulBuild/artifact/past-jobs.json" \\
 					|| ! jq 'empty' past-jobs.json \\
 				; then
-					# temporary migration of old data
-					if ! wget --timeout=5 -qO past-jobs.json "$JOB_URL/lastSuccessfulBuild/artifact/pastFailedJobs.json" || ! jq 'empty' past-jobs.json; then
-						echo '{}' > past-jobs.json
-					fi
+					echo '{}' > past-jobs.json
 				fi
 				jq -c -L.scripts --slurpfile pastJobs past-jobs.json '
 					include "jenkins";

--- a/Jenkinsfile.trigger
+++ b/Jenkinsfile.trigger
@@ -207,8 +207,10 @@ node {
 					set -Eeuo pipefail -x
 
 					jq <<<"$currentJobsJson" '
+						# save firstTime if it is not set yet
+						map_values(.firstTime //= .lastTime)
 						# merge the two objects recursively, preferring data from "buildCompletionDataJson"
-						. * ( env.buildCompletionDataJson | fromjson )
+						| . * ( env.buildCompletionDataJson | fromjson )
 					' | tee past-jobs.json
 				'''
 				archiveArtifacts(


### PR DESCRIPTION
just some extra data so we can see what time this started failing without having to calculate based on skips, count, and assuming the job ran every hour.

I meant to include this in https://github.com/docker-library/meta-scripts/pull/91, but it got lost in the refactors.

Also drop temporary migration of `pastFailedJobs.json` since it isn't necessary anymore.