### PR TITLE
Improve permissions and give Laurent permission to the DOI list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @tianon @yosifkit
+*  @docker-library/maintainers
+
+/doi.jq  @LaurentGoderre  @docker-library/maintainers


### PR DESCRIPTION
TODO: Add the `@docker-library/maintainers` group to this repo