### PR TITLE
Speed up deploy optimistically

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -70,8 +70,26 @@ node('put-shared') { ansiColor('xterm') {
 					include "deploy";
 					arch_tagged_manifests(env.BASHBREW_ARCH)
 					| deploy_objects[]
-				' builds.json | tee deploy.json
+				' builds.json > deploy.json
 			'''
+		}
+		stage('Filter') {
+			// using the previous successful deploy.json, filter the current deploy.json with items already pushed last time
+			sh'''
+				wget --timeout=5 -qO past-deploy.json "$JOB_URL/lastSuccessfulBuild/artifact/deploy.json"
+				# swap to this touch instead of the wget above to (re)bootstrap
+				#touch past-deploy.json
+				jq --slurpfile past ./past-deploy.json 'select( IN($past[]) | not )' ./deploy.json > filtered-deploy.json
+			'''
+		}
+		stage('Archive') {
+			archiveArtifacts(
+				artifacts: [
+					'deploy.json',
+					'filtered-deploy.json',
+				].join(','),
+				fingerprint: true,
+			)
 		}
 
 		withCredentials([
@@ -89,7 +107,7 @@ node('put-shared') { ansiColor('xterm') {
 							./.go-env.sh go build -trimpath -o bin/deploy ./cmd/deploy
 						fi
 					)
-					.scripts/bin/deploy < deploy.json
+					.scripts/bin/deploy < filtered-deploy.json
 				'''
 			}
 		}


### PR DESCRIPTION
Trust that if an item was pushed successfully in a previous deploy, then we don't need to push it this time.

We can "Replay" a job with an adjusted filter stage to skip the filtering (i.e., skip the `wget` and just use an empty `past-deploy.json`) to get the previous behavior of pushing everything.

Test jobs:
- https://doi-janky.infosiftr.net/job/meta/view/deploys/job/arm32v5/job/deploy/11747/ (no previous `deploy.json`)
- https://doi-janky.infosiftr.net/job/meta/view/deploys/job/arm32v5/job/deploy/11748/ (successful good path)
- https://doi-janky.infosiftr.net/job/meta/view/deploys/job/arm32v5/job/deploy/11749/ (purposely falling with bad archived artifacts)
- https://doi-janky.infosiftr.net/job/meta/view/deploys/job/arm32v5/job/deploy/11750/ (not affected by past failed job, downloads past `deploy.json` from `lastSuccessfulBuild`)