### PR TITLE
Remove `DOCKERHUB_PUBLIC_PROXY_HOST` from Jenkinsfiles

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -76,7 +76,6 @@ node('put-shared') { ansiColor('xterm') {
 
 		withCredentials([
 			string(credentialsId: 'dockerhub-public-proxy', variable: 'DOCKERHUB_PUBLIC_PROXY'),
-			string(credentialsId: 'dockerhub-public-proxy-host', variable: 'DOCKERHUB_PUBLIC_PROXY_HOST'),
 		]) {
 			stage('Deploy') {
 				sh '''#!/usr/bin/env bash

--- a/Jenkinsfile.meta
+++ b/Jenkinsfile.meta
@@ -51,7 +51,6 @@ node {
 		withCredentials([
 			// thanks to rate limits, we either have to "docker login" or look things up via our proxy
 			string(credentialsId: 'dockerhub-public-proxy', variable: 'DOCKERHUB_PUBLIC_PROXY'),
-			string(credentialsId: 'dockerhub-public-proxy-host', variable: 'DOCKERHUB_PUBLIC_PROXY_HOST'),
 		]) {
 			stage('Fetch') {
 				sh 'bashbrew --library .doi/library fetch --all'


### PR DESCRIPTION
This notably does *not* remove support for reading this variable from `registry/client.go`, but it does remove the one place (here) we set it directly since we don't actually use it anymore (since #38).