### PR TITLE
Save full list of entries for every source

### DIFF
--- a/.test/builds.json
+++ b/.test/builds.json
@@ -77,15 +77,17 @@
     "source": {
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
       "reproducibleGitChecksum": "52d3d61b1e9d12310646ec3935698a5825bf568cecc5b5fbbf4e4c4a59e53e8b",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-        "Directory": "24/cli",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1700741054
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+          "Directory": "24/cli",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1700741054
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -182,15 +184,17 @@
     "source": {
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
       "reproducibleGitChecksum": "52d3d61b1e9d12310646ec3935698a5825bf568cecc5b5fbbf4e4c4a59e53e8b",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-        "Directory": "24/cli",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1700741054
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+          "Directory": "24/cli",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1700741054
+        }
+      ],
       "arches": {
         "arm32v6": {
           "tags": [
@@ -307,15 +311,17 @@
     "source": {
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
       "reproducibleGitChecksum": "52d3d61b1e9d12310646ec3935698a5825bf568cecc5b5fbbf4e4c4a59e53e8b",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-        "Directory": "24/cli",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1700741054
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+          "Directory": "24/cli",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1700741054
+        }
+      ],
       "arches": {
         "arm32v7": {
           "tags": [
@@ -432,15 +438,17 @@
     "source": {
       "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
       "reproducibleGitChecksum": "52d3d61b1e9d12310646ec3935698a5825bf568cecc5b5fbbf4e4c4a59e53e8b",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-        "Directory": "24/cli",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1700741054
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+          "Directory": "24/cli",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1700741054
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -574,15 +582,17 @@
     "source": {
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
       "reproducibleGitChecksum": "e3ba9d8210082fcd33d20c53d99fc72f7a44d0d0a8abb5a4d6f54710b91f4c46",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-        "Directory": "24/dind",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1701129870
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+          "Directory": "24/dind",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1701129870
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -689,15 +699,17 @@
     "source": {
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
       "reproducibleGitChecksum": "e3ba9d8210082fcd33d20c53d99fc72f7a44d0d0a8abb5a4d6f54710b91f4c46",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-        "Directory": "24/dind",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1701129870
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+          "Directory": "24/dind",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1701129870
+        }
+      ],
       "arches": {
         "arm32v6": {
           "tags": [
@@ -843,15 +855,17 @@
     "source": {
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
       "reproducibleGitChecksum": "e3ba9d8210082fcd33d20c53d99fc72f7a44d0d0a8abb5a4d6f54710b91f4c46",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-        "Directory": "24/dind",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1701129870
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+          "Directory": "24/dind",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1701129870
+        }
+      ],
       "arches": {
         "arm32v7": {
           "tags": [
@@ -997,15 +1011,17 @@
     "source": {
       "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
       "reproducibleGitChecksum": "e3ba9d8210082fcd33d20c53d99fc72f7a44d0d0a8abb5a4d6f54710b91f4c46",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-        "Directory": "24/dind",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1701129870
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+          "Directory": "24/dind",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1701129870
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -1116,15 +1132,17 @@
     "source": {
       "sourceId": "fc50de1b0dedf55655271fc22721b7d94e09a12d0e6ff6b76871ba6b808f5984",
       "reproducibleGitChecksum": "1711f6dcb5def8e2e6ce88e3a12c24e2dd37bf967a79ae86128c4d45429c0a2c",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-        "Directory": "24/windows/windowsservercore-ltsc2022",
-        "File": "Dockerfile",
-        "Builder": "classic",
-        "SOURCE_DATE_EPOCH": 1700741054
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+          "Directory": "24/windows/windowsservercore-ltsc2022",
+          "File": "Dockerfile",
+          "Builder": "classic",
+          "SOURCE_DATE_EPOCH": 1700741054
+        }
+      ],
       "arches": {
         "windows-amd64": {
           "tags": [
@@ -1230,15 +1248,17 @@
     "source": {
       "sourceId": "10083d7e3bfbe4f9bdb3e38e4846b88d0bea1896caca9ef70de6478b3c20fe9a",
       "reproducibleGitChecksum": "40dcbc9e7a451cfc7f2bd12400074f3f21bc6c0331e249019623aeb617d18747",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/docker.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-        "Directory": "24/windows/windowsservercore-1809",
-        "File": "Dockerfile",
-        "Builder": "classic",
-        "SOURCE_DATE_EPOCH": 1700741054
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/docker.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+          "Directory": "24/windows/windowsservercore-1809",
+          "File": "Dockerfile",
+          "Builder": "classic",
+          "SOURCE_DATE_EPOCH": 1700741054
+        }
+      ],
       "arches": {
         "windows-amd64": {
           "tags": [
@@ -1381,15 +1401,17 @@
     "source": {
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
       "reproducibleGitChecksum": "63f1341601bbdd5930b9ce39f12c2a8c176d581e2687f9997444287b469409b0",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-server",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-server",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -1510,15 +1532,17 @@
     "source": {
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
       "reproducibleGitChecksum": "63f1341601bbdd5930b9ce39f12c2a8c176d581e2687f9997444287b469409b0",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-server",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-server",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "arm32v6": {
           "tags": [
@@ -1659,15 +1683,17 @@
     "source": {
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
       "reproducibleGitChecksum": "63f1341601bbdd5930b9ce39f12c2a8c176d581e2687f9997444287b469409b0",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-server",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-server",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -1805,15 +1831,17 @@
     "source": {
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
       "reproducibleGitChecksum": "63f1341601bbdd5930b9ce39f12c2a8c176d581e2687f9997444287b469409b0",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-server",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-server",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "i386": {
           "tags": [
@@ -1950,15 +1978,17 @@
     "source": {
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
       "reproducibleGitChecksum": "63f1341601bbdd5930b9ce39f12c2a8c176d581e2687f9997444287b469409b0",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-server",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-server",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "ppc64le": {
           "tags": [
@@ -2095,15 +2125,17 @@
     "source": {
       "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
       "reproducibleGitChecksum": "63f1341601bbdd5930b9ce39f12c2a8c176d581e2687f9997444287b469409b0",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-server",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-server",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "s390x": {
           "tags": [
@@ -2240,15 +2272,17 @@
     "source": {
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
       "reproducibleGitChecksum": "1af0a47c1f09f04f907156b2c6ee9df1eb2a71185bcddb9880ecf38b1fd69956",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-signer",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-signer",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -2369,15 +2403,17 @@
     "source": {
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
       "reproducibleGitChecksum": "1af0a47c1f09f04f907156b2c6ee9df1eb2a71185bcddb9880ecf38b1fd69956",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-signer",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-signer",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "arm32v6": {
           "tags": [
@@ -2518,15 +2554,17 @@
     "source": {
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
       "reproducibleGitChecksum": "1af0a47c1f09f04f907156b2c6ee9df1eb2a71185bcddb9880ecf38b1fd69956",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-signer",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-signer",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -2664,15 +2702,17 @@
     "source": {
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
       "reproducibleGitChecksum": "1af0a47c1f09f04f907156b2c6ee9df1eb2a71185bcddb9880ecf38b1fd69956",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-signer",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-signer",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "i386": {
           "tags": [
@@ -2809,15 +2849,17 @@
     "source": {
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
       "reproducibleGitChecksum": "1af0a47c1f09f04f907156b2c6ee9df1eb2a71185bcddb9880ecf38b1fd69956",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-signer",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-signer",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "ppc64le": {
           "tags": [
@@ -2954,15 +2996,17 @@
     "source": {
       "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
       "reproducibleGitChecksum": "1af0a47c1f09f04f907156b2c6ee9df1eb2a71185bcddb9880ecf38b1fd69956",
-      "entry": {
-        "GitRepo": "https://github.com/docker/notary-official-images.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-        "Directory": "notary-signer",
-        "File": "Dockerfile",
-        "Builder": "buildkit",
-        "SOURCE_DATE_EPOCH": 1666649444
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker/notary-official-images.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+          "Directory": "notary-signer",
+          "File": "Dockerfile",
+          "Builder": "buildkit",
+          "SOURCE_DATE_EPOCH": 1666649444
+        }
+      ],
       "arches": {
         "s390x": {
           "tags": [
@@ -3038,15 +3082,17 @@
     "source": {
       "sourceId": "df39fa95e66c7e19e56af0f9dfb8b79b15a0422a9b44eb0f16274d3f1f8939a2",
       "reproducibleGitChecksum": "17e76ce3a5b47357c5724738db231ed2477c94d43df69ce34ae0871c99f7de78",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-amd64",
-        "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
-        "Directory": "latest/glibc/amd64",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-amd64",
+          "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
+          "Directory": "latest/glibc/amd64",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -3133,15 +3179,17 @@
     "source": {
       "sourceId": "b3980edf950afc2ae7180a73ac06ddc9bcaab81cd114aae7df8392f1f35f892e",
       "reproducibleGitChecksum": "b9cd3fd9104af7427dd8328524fcdf0bc72a5f37da5e803d1e4f5eacf09a5089",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm32v5",
-        "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
-        "Directory": "latest/glibc/arm32v5",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm32v5",
+          "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
+          "Directory": "latest/glibc/arm32v5",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm32v5": {
           "tags": [
@@ -3229,15 +3277,17 @@
     "source": {
       "sourceId": "421c676ba4e46b3e8aea52d35c8f7abb90ac02f2c21620b163368a5ffd61ca42",
       "reproducibleGitChecksum": "87d20b767462df91b125a3f1e79239da0bfc4c9da8ebd0f83648714d905029d0",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm32v6",
-        "GitCommit": "c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5",
-        "Directory": "latest/musl/arm32v6",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm32v6",
+          "GitCommit": "c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5",
+          "Directory": "latest/musl/arm32v6",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm32v6": {
           "tags": [
@@ -3325,15 +3375,17 @@
     "source": {
       "sourceId": "c994e7d0aa868570e8ee977e2872d1e6ab51c475718e3fa6840a063df3b2d222",
       "reproducibleGitChecksum": "af0ae1b14b8f4948eddffa8793791a267870f343fd072e0304834ee800f9732e",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm32v7",
-        "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
-        "Directory": "latest/glibc/arm32v7",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm32v7",
+          "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
+          "Directory": "latest/glibc/arm32v7",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm32v7": {
           "tags": [
@@ -3421,15 +3473,17 @@
     "source": {
       "sourceId": "6df3b92e1fb8d579399af7a60ab66f16c8af07edef1fd92b19bb0f1e1272bacd",
       "reproducibleGitChecksum": "54bcd95fc260d3d478b097eaf7541c24f70ff8d6d8d09a132033789349acfcca",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm64v8",
-        "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
-        "Directory": "latest/glibc/arm64v8",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm64v8",
+          "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
+          "Directory": "latest/glibc/arm64v8",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -3516,15 +3570,17 @@
     "source": {
       "sourceId": "47078b58d39eb8284b41386f288be91f7cb7b0a99e2789cedf10e2a8dffdd524",
       "reproducibleGitChecksum": "ebaf8389e11a5ed571a2d934b59ab02d0f7e9181f338d960a98e69ca5ae0a020",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-i386",
-        "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
-        "Directory": "latest/glibc/i386",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-i386",
+          "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
+          "Directory": "latest/glibc/i386",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "i386": {
           "tags": [
@@ -3610,15 +3666,17 @@
     "source": {
       "sourceId": "8b56ef1cfc9211b77472a7e939aa15422dcc6d87e02772731cbb318f799dbba4",
       "reproducibleGitChecksum": "b07cede4baa85b37cac67e2e3a9c2644d7cc8599fbbe7d440bd1965371d7c16f",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-mips64le",
-        "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
-        "Directory": "latest/glibc/mips64le",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-mips64le",
+          "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
+          "Directory": "latest/glibc/mips64le",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "mips64le": {
           "tags": [
@@ -3704,15 +3762,17 @@
     "source": {
       "sourceId": "c11a0df72b00371fc02029c12d79cb82dd7f906da3890a64e14cfe47e92e68db",
       "reproducibleGitChecksum": "f9cd472cc7b1228b9c2318c547fb3a954d2cbe1fb0bc04c5e871b0158b5d5adb",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-ppc64le",
-        "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
-        "Directory": "latest/glibc/ppc64le",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-ppc64le",
+          "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
+          "Directory": "latest/glibc/ppc64le",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "ppc64le": {
           "tags": [
@@ -3798,15 +3858,17 @@
     "source": {
       "sourceId": "45b99857330b33443792583e07608a201820afa4b04b916b84682af97d16000a",
       "reproducibleGitChecksum": "e6549a760e04114ed4fb344ad095430c0b07657e8d9cdcc737181273c071981e",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-riscv64",
-        "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
-        "Directory": "latest/uclibc/riscv64",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-riscv64",
+          "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
+          "Directory": "latest/uclibc/riscv64",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "riscv64": {
           "tags": [
@@ -3892,15 +3954,17 @@
     "source": {
       "sourceId": "84e209ff3d62b1b76bc238e61391935039b8543e2b6777c792ec52df2ebde99b",
       "reproducibleGitChecksum": "6269faba1236ba6494bffcc94c9b3cc262a7efabd9e9f65e5dc9df1e40339c30",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-s390x",
-        "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
-        "Directory": "latest/glibc/s390x",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-s390x",
+          "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
+          "Directory": "latest/glibc/s390x",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "s390x": {
           "tags": [
@@ -3986,15 +4050,17 @@
     "source": {
       "sourceId": "129f2d1a13eb71a56af0e06fea1b4d505c1c035b84dad96676693248ebe60299",
       "reproducibleGitChecksum": "daf1f21d9740e773d1dc6bdb8e0fdae08ffade5f69617abd4f615aa39df06ab5",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-riscv64",
-        "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
-        "Directory": "latest/glibc/riscv64",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-riscv64",
+          "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
+          "Directory": "latest/glibc/riscv64",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "riscv64": {
           "tags": [
@@ -4070,15 +4136,17 @@
     "source": {
       "sourceId": "525c761d1a8e96f9ec1c499b0dce0ff4f1ed7a8c568f86fcf9f5d3c51e870126",
       "reproducibleGitChecksum": "a3e7286345afcef13f3ddba0d34e7e9de2a490ee1983d193d2c9d7524404195a",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-amd64",
-        "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
-        "Directory": "latest/musl/amd64",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-amd64",
+          "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
+          "Directory": "latest/musl/amd64",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -4155,15 +4223,17 @@
     "source": {
       "sourceId": "9753cb67f1598fd7aa426d1cdfed398fa81e5619075ee5df5aefe46cb7417df0",
       "reproducibleGitChecksum": "c28d23b61a78f989ecfd9a4887e818b4d29c96bdf54783f4c90935843e8c00a4",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm32v7",
-        "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
-        "Directory": "latest/musl/arm32v7",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm32v7",
+          "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
+          "Directory": "latest/musl/arm32v7",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm32v7": {
           "tags": [
@@ -4241,15 +4311,17 @@
     "source": {
       "sourceId": "b81a79eee6c6d37be4b867dad59b9fefbb36e0eedf879cf1c2cf8ea5d05e3124",
       "reproducibleGitChecksum": "99149604120ea53fce493cd15e2d46dcc4a0c95fca2cc42b80fff27cc7c29033",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm64v8",
-        "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
-        "Directory": "latest/musl/arm64v8",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm64v8",
+          "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
+          "Directory": "latest/musl/arm64v8",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -4326,15 +4398,17 @@
     "source": {
       "sourceId": "51e5747cd366107e1a7cca46a2e099925813974ce63b9078d9626b50b48fae5e",
       "reproducibleGitChecksum": "6e88131ed46179b9091c6d411dcf1cd97908ccab721106885823a24c40d09841",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-i386",
-        "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
-        "Directory": "latest/musl/i386",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-i386",
+          "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
+          "Directory": "latest/musl/i386",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "i386": {
           "tags": [
@@ -4410,15 +4484,17 @@
     "source": {
       "sourceId": "28ef7af06435ce6e9bd92c7fb07fa1930ef08299aea37b9b71875a6c71d2a5e0",
       "reproducibleGitChecksum": "0edf4a03cf0abab4dc3ddb643ea2557011441c94756fcb4219fd0accdbd15087",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-ppc64le",
-        "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
-        "Directory": "latest/musl/ppc64le",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-ppc64le",
+          "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
+          "Directory": "latest/musl/ppc64le",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "ppc64le": {
           "tags": [
@@ -4494,15 +4570,17 @@
     "source": {
       "sourceId": "23d7aabdd6ac37efd6230bb6e3d07d0b0019a90f71915ec053e2cbec8647939f",
       "reproducibleGitChecksum": "184229820dec5f0ec79b8dff338a57b5753b86d0deb662c77dc4b4e1a4e191d2",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-riscv64",
-        "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
-        "Directory": "latest/musl/riscv64",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-riscv64",
+          "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
+          "Directory": "latest/musl/riscv64",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "riscv64": {
           "tags": [
@@ -4578,15 +4656,17 @@
     "source": {
       "sourceId": "937ba89cafe61fe48b4e7b167307a40a5060630417cc5bbb35f2557aae5e6de4",
       "reproducibleGitChecksum": "f1eec923f99f36025636a3c1ae130aedfed7779c3764e20ff863d2cc6d04ac07",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-s390x",
-        "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
-        "Directory": "latest/musl/s390x",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-s390x",
+          "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
+          "Directory": "latest/musl/s390x",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "s390x": {
           "tags": [
@@ -4662,15 +4742,17 @@
     "source": {
       "sourceId": "6a18227ecb1f42bd4755b0843ab3d0752a23b193efb5e9a969b0760ddd19cf8a",
       "reproducibleGitChecksum": "27d63f8ad18605a011ba51ad8d751137ced48cda3bf7b0d57d0b703a5a758d1b",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-amd64",
-        "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
-        "Directory": "latest/uclibc/amd64",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-amd64",
+          "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
+          "Directory": "latest/uclibc/amd64",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -4747,15 +4829,17 @@
     "source": {
       "sourceId": "db872cd091599cf2e7122035b6695f91e0da175083da118d84ed3fad9fac5714",
       "reproducibleGitChecksum": "53b36cefd44161ae6ac336e26d895b7de646814e3e09d05554e91d982740f744",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm32v5",
-        "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
-        "Directory": "latest/uclibc/arm32v5",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm32v5",
+          "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
+          "Directory": "latest/uclibc/arm32v5",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm32v5": {
           "tags": [
@@ -4833,15 +4917,17 @@
     "source": {
       "sourceId": "1ca52688d8766979871c1959cb49752aea3b61f526e94155bec9c2781eacdf11",
       "reproducibleGitChecksum": "ece85a849af3c4b2468de15350257970aa7bd36e23607a0aab3f58b4d6e6e659",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm32v7",
-        "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
-        "Directory": "latest/uclibc/arm32v7",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm32v7",
+          "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
+          "Directory": "latest/uclibc/arm32v7",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm32v7": {
           "tags": [
@@ -4919,15 +5005,17 @@
     "source": {
       "sourceId": "3987c80147f7aef388ae723a6bce970fa724a17b3cb74a2e4f4a058204caa7d0",
       "reproducibleGitChecksum": "a9ff0eba05d9c907b2fdf3bbc9eb397e67dcc0944063cbfae5be30b60440f116",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-arm64v8",
-        "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
-        "Directory": "latest/uclibc/arm64v8",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-arm64v8",
+          "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
+          "Directory": "latest/uclibc/arm64v8",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -5004,15 +5092,17 @@
     "source": {
       "sourceId": "5d3c7f5271e2c2f8c25fd7583e20946c9756be806d554837f4aff3247438cdc6",
       "reproducibleGitChecksum": "882db5aa14620ea7decded765d64f05700feb25b1770a5a4817e4d8e08fec920",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-i386",
-        "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
-        "Directory": "latest/uclibc/i386",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-i386",
+          "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
+          "Directory": "latest/uclibc/i386",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "i386": {
           "tags": [
@@ -5088,15 +5178,17 @@
     "source": {
       "sourceId": "b0bb94feb28087aee21e4a4c0b9cd51b0ba4737c166033e34fa245433b0f7447",
       "reproducibleGitChecksum": "acfeadf772789a80427f642691efcb0daeeabe73ce4753318f25760c3ead6e18",
-      "entry": {
-        "GitRepo": "https://github.com/docker-library/busybox.git",
-        "GitFetch": "refs/heads/dist-mips64le",
-        "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
-        "Directory": "latest/uclibc/mips64le",
-        "File": "index.json",
-        "Builder": "oci-import",
-        "SOURCE_DATE_EPOCH": 1709081058
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/docker-library/busybox.git",
+          "GitFetch": "refs/heads/dist-mips64le",
+          "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
+          "Directory": "latest/uclibc/mips64le",
+          "File": "index.json",
+          "Builder": "oci-import",
+          "SOURCE_DATE_EPOCH": 1709081058
+        }
+      ],
       "arches": {
         "mips64le": {
           "tags": [
@@ -5213,15 +5305,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "amd64": {
           "tags": [
@@ -5334,15 +5428,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "arm32v5": {
           "tags": [
@@ -5456,15 +5552,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "arm32v7": {
           "tags": [
@@ -5578,15 +5676,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "arm64v8": {
           "tags": [
@@ -5698,15 +5798,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "i386": {
           "tags": [
@@ -5817,15 +5919,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "mips64le": {
           "tags": [
@@ -5936,15 +6040,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "ppc64le": {
           "tags": [
@@ -6055,15 +6161,17 @@
     "source": {
       "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "s390x": {
           "tags": [
@@ -6174,15 +6282,17 @@
     "source": {
       "sourceId": "e141d79c2a22ece4486416cbea97b88bf7595236e866e396d42353cb0d3e1633",
       "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-      "entry": {
-        "GitRepo": "https://github.com/tianon/dockerfiles.git",
-        "GitFetch": "refs/heads/master",
-        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-        "Directory": "infosiftr-moby",
-        "File": "Dockerfile.unstable",
-        "Builder": "",
-        "SOURCE_DATE_EPOCH": 1709705469
-      },
+      "entries": [
+        {
+          "GitRepo": "https://github.com/tianon/dockerfiles.git",
+          "GitFetch": "refs/heads/master",
+          "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+          "Directory": "infosiftr-moby",
+          "File": "Dockerfile.unstable",
+          "Builder": "",
+          "SOURCE_DATE_EPOCH": 1709705469
+        }
+      ],
       "arches": {
         "riscv64": {
           "tags": [

--- a/.test/sources.json
+++ b/.test/sources.json
@@ -2,15 +2,17 @@
   "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b": {
     "sourceId": "76d7d7d66aeb62eb797c8475407e6cd2b6ad262957a622035f81fb93e532b36b",
     "reproducibleGitChecksum": "52d3d61b1e9d12310646ec3935698a5825bf568cecc5b5fbbf4e4c4a59e53e8b",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/docker.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-      "Directory": "24/cli",
-      "File": "Dockerfile",
-      "Builder": "buildkit",
-      "SOURCE_DATE_EPOCH": 1700741054
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/docker.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+        "Directory": "24/cli",
+        "File": "Dockerfile",
+        "Builder": "buildkit",
+        "SOURCE_DATE_EPOCH": 1700741054
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -144,15 +146,17 @@
   "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3": {
     "sourceId": "1f55272eded1ab37d8303492366ef26e8757c8210b24a4cb08f4fe2d63c692e3",
     "reproducibleGitChecksum": "e3ba9d8210082fcd33d20c53d99fc72f7a44d0d0a8abb5a4d6f54710b91f4c46",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/docker.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
-      "Directory": "24/dind",
-      "File": "Dockerfile",
-      "Builder": "buildkit",
-      "SOURCE_DATE_EPOCH": 1701129870
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/docker.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "99073a3b6be3aa7e6b5af1e69509e8c532254500",
+        "Directory": "24/dind",
+        "File": "Dockerfile",
+        "Builder": "buildkit",
+        "SOURCE_DATE_EPOCH": 1701129870
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -326,15 +330,17 @@
   "fc50de1b0dedf55655271fc22721b7d94e09a12d0e6ff6b76871ba6b808f5984": {
     "sourceId": "fc50de1b0dedf55655271fc22721b7d94e09a12d0e6ff6b76871ba6b808f5984",
     "reproducibleGitChecksum": "1711f6dcb5def8e2e6ce88e3a12c24e2dd37bf967a79ae86128c4d45429c0a2c",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/docker.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-      "Directory": "24/windows/windowsservercore-ltsc2022",
-      "File": "Dockerfile",
-      "Builder": "classic",
-      "SOURCE_DATE_EPOCH": 1700741054
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/docker.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+        "Directory": "24/windows/windowsservercore-ltsc2022",
+        "File": "Dockerfile",
+        "Builder": "classic",
+        "SOURCE_DATE_EPOCH": 1700741054
+      }
+    ],
     "arches": {
       "windows-amd64": {
         "tags": [
@@ -378,15 +384,17 @@
   "10083d7e3bfbe4f9bdb3e38e4846b88d0bea1896caca9ef70de6478b3c20fe9a": {
     "sourceId": "10083d7e3bfbe4f9bdb3e38e4846b88d0bea1896caca9ef70de6478b3c20fe9a",
     "reproducibleGitChecksum": "40dcbc9e7a451cfc7f2bd12400074f3f21bc6c0331e249019623aeb617d18747",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/docker.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
-      "Directory": "24/windows/windowsservercore-1809",
-      "File": "Dockerfile",
-      "Builder": "classic",
-      "SOURCE_DATE_EPOCH": 1700741054
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/docker.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "6d541d27b5dd12639e5a33a675ebca04d3837d74",
+        "Directory": "24/windows/windowsservercore-1809",
+        "File": "Dockerfile",
+        "Builder": "classic",
+        "SOURCE_DATE_EPOCH": 1700741054
+      }
+    ],
     "arches": {
       "windows-amd64": {
         "tags": [
@@ -430,15 +438,17 @@
   "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4": {
     "sourceId": "a9f3e362f7d26c466c22529d0a01d527e8900cbd9e0fabd2cc0ce342868768c4",
     "reproducibleGitChecksum": "63f1341601bbdd5930b9ce39f12c2a8c176d581e2687f9997444287b469409b0",
-    "entry": {
-      "GitRepo": "https://github.com/docker/notary-official-images.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-      "Directory": "notary-server",
-      "File": "Dockerfile",
-      "Builder": "buildkit",
-      "SOURCE_DATE_EPOCH": 1666649444
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker/notary-official-images.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+        "Directory": "notary-server",
+        "File": "Dockerfile",
+        "Builder": "buildkit",
+        "SOURCE_DATE_EPOCH": 1666649444
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -633,15 +643,17 @@
   "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8": {
     "sourceId": "ae57bf4b8a7a08916ab01ec22da5d389716f39e9040d2c6f711283d7f8600da8",
     "reproducibleGitChecksum": "1af0a47c1f09f04f907156b2c6ee9df1eb2a71185bcddb9880ecf38b1fd69956",
-    "entry": {
-      "GitRepo": "https://github.com/docker/notary-official-images.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
-      "Directory": "notary-signer",
-      "File": "Dockerfile",
-      "Builder": "buildkit",
-      "SOURCE_DATE_EPOCH": 1666649444
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker/notary-official-images.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "77b9b7833f8dd6be07104b214193788795a320ff",
+        "Directory": "notary-signer",
+        "File": "Dockerfile",
+        "Builder": "buildkit",
+        "SOURCE_DATE_EPOCH": 1666649444
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -836,15 +848,17 @@
   "df39fa95e66c7e19e56af0f9dfb8b79b15a0422a9b44eb0f16274d3f1f8939a2": {
     "sourceId": "df39fa95e66c7e19e56af0f9dfb8b79b15a0422a9b44eb0f16274d3f1f8939a2",
     "reproducibleGitChecksum": "17e76ce3a5b47357c5724738db231ed2477c94d43df69ce34ae0871c99f7de78",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-amd64",
-      "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
-      "Directory": "latest/glibc/amd64",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-amd64",
+        "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
+        "Directory": "latest/glibc/amd64",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -892,15 +906,17 @@
   "b3980edf950afc2ae7180a73ac06ddc9bcaab81cd114aae7df8392f1f35f892e": {
     "sourceId": "b3980edf950afc2ae7180a73ac06ddc9bcaab81cd114aae7df8392f1f35f892e",
     "reproducibleGitChecksum": "b9cd3fd9104af7427dd8328524fcdf0bc72a5f37da5e803d1e4f5eacf09a5089",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm32v5",
-      "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
-      "Directory": "latest/glibc/arm32v5",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm32v5",
+        "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
+        "Directory": "latest/glibc/arm32v5",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm32v5": {
         "tags": [
@@ -949,15 +965,17 @@
   "421c676ba4e46b3e8aea52d35c8f7abb90ac02f2c21620b163368a5ffd61ca42": {
     "sourceId": "421c676ba4e46b3e8aea52d35c8f7abb90ac02f2c21620b163368a5ffd61ca42",
     "reproducibleGitChecksum": "87d20b767462df91b125a3f1e79239da0bfc4c9da8ebd0f83648714d905029d0",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm32v6",
-      "GitCommit": "c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5",
-      "Directory": "latest/musl/arm32v6",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm32v6",
+        "GitCommit": "c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5",
+        "Directory": "latest/musl/arm32v6",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm32v6": {
         "tags": [
@@ -1006,15 +1024,17 @@
   "c994e7d0aa868570e8ee977e2872d1e6ab51c475718e3fa6840a063df3b2d222": {
     "sourceId": "c994e7d0aa868570e8ee977e2872d1e6ab51c475718e3fa6840a063df3b2d222",
     "reproducibleGitChecksum": "af0ae1b14b8f4948eddffa8793791a267870f343fd072e0304834ee800f9732e",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm32v7",
-      "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
-      "Directory": "latest/glibc/arm32v7",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm32v7",
+        "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
+        "Directory": "latest/glibc/arm32v7",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm32v7": {
         "tags": [
@@ -1063,15 +1083,17 @@
   "6df3b92e1fb8d579399af7a60ab66f16c8af07edef1fd92b19bb0f1e1272bacd": {
     "sourceId": "6df3b92e1fb8d579399af7a60ab66f16c8af07edef1fd92b19bb0f1e1272bacd",
     "reproducibleGitChecksum": "54bcd95fc260d3d478b097eaf7541c24f70ff8d6d8d09a132033789349acfcca",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm64v8",
-      "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
-      "Directory": "latest/glibc/arm64v8",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm64v8",
+        "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
+        "Directory": "latest/glibc/arm64v8",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm64v8": {
         "tags": [
@@ -1120,15 +1142,17 @@
   "47078b58d39eb8284b41386f288be91f7cb7b0a99e2789cedf10e2a8dffdd524": {
     "sourceId": "47078b58d39eb8284b41386f288be91f7cb7b0a99e2789cedf10e2a8dffdd524",
     "reproducibleGitChecksum": "ebaf8389e11a5ed571a2d934b59ab02d0f7e9181f338d960a98e69ca5ae0a020",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-i386",
-      "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
-      "Directory": "latest/glibc/i386",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-i386",
+        "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
+        "Directory": "latest/glibc/i386",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "i386": {
         "tags": [
@@ -1176,15 +1200,17 @@
   "8b56ef1cfc9211b77472a7e939aa15422dcc6d87e02772731cbb318f799dbba4": {
     "sourceId": "8b56ef1cfc9211b77472a7e939aa15422dcc6d87e02772731cbb318f799dbba4",
     "reproducibleGitChecksum": "b07cede4baa85b37cac67e2e3a9c2644d7cc8599fbbe7d440bd1965371d7c16f",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-mips64le",
-      "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
-      "Directory": "latest/glibc/mips64le",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-mips64le",
+        "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
+        "Directory": "latest/glibc/mips64le",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "mips64le": {
         "tags": [
@@ -1232,15 +1258,17 @@
   "c11a0df72b00371fc02029c12d79cb82dd7f906da3890a64e14cfe47e92e68db": {
     "sourceId": "c11a0df72b00371fc02029c12d79cb82dd7f906da3890a64e14cfe47e92e68db",
     "reproducibleGitChecksum": "f9cd472cc7b1228b9c2318c547fb3a954d2cbe1fb0bc04c5e871b0158b5d5adb",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-ppc64le",
-      "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
-      "Directory": "latest/glibc/ppc64le",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-ppc64le",
+        "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
+        "Directory": "latest/glibc/ppc64le",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "ppc64le": {
         "tags": [
@@ -1288,15 +1316,17 @@
   "45b99857330b33443792583e07608a201820afa4b04b916b84682af97d16000a": {
     "sourceId": "45b99857330b33443792583e07608a201820afa4b04b916b84682af97d16000a",
     "reproducibleGitChecksum": "e6549a760e04114ed4fb344ad095430c0b07657e8d9cdcc737181273c071981e",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-riscv64",
-      "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
-      "Directory": "latest/uclibc/riscv64",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-riscv64",
+        "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
+        "Directory": "latest/uclibc/riscv64",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "riscv64": {
         "tags": [
@@ -1344,15 +1374,17 @@
   "84e209ff3d62b1b76bc238e61391935039b8543e2b6777c792ec52df2ebde99b": {
     "sourceId": "84e209ff3d62b1b76bc238e61391935039b8543e2b6777c792ec52df2ebde99b",
     "reproducibleGitChecksum": "6269faba1236ba6494bffcc94c9b3cc262a7efabd9e9f65e5dc9df1e40339c30",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-s390x",
-      "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
-      "Directory": "latest/glibc/s390x",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-s390x",
+        "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
+        "Directory": "latest/glibc/s390x",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "s390x": {
         "tags": [
@@ -1400,15 +1432,17 @@
   "129f2d1a13eb71a56af0e06fea1b4d505c1c035b84dad96676693248ebe60299": {
     "sourceId": "129f2d1a13eb71a56af0e06fea1b4d505c1c035b84dad96676693248ebe60299",
     "reproducibleGitChecksum": "daf1f21d9740e773d1dc6bdb8e0fdae08ffade5f69617abd4f615aa39df06ab5",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-riscv64",
-      "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
-      "Directory": "latest/glibc/riscv64",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-riscv64",
+        "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
+        "Directory": "latest/glibc/riscv64",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "riscv64": {
         "tags": [
@@ -1446,15 +1480,17 @@
   "525c761d1a8e96f9ec1c499b0dce0ff4f1ed7a8c568f86fcf9f5d3c51e870126": {
     "sourceId": "525c761d1a8e96f9ec1c499b0dce0ff4f1ed7a8c568f86fcf9f5d3c51e870126",
     "reproducibleGitChecksum": "a3e7286345afcef13f3ddba0d34e7e9de2a490ee1983d193d2c9d7524404195a",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-amd64",
-      "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
-      "Directory": "latest/musl/amd64",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-amd64",
+        "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
+        "Directory": "latest/musl/amd64",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -1492,15 +1528,17 @@
   "9753cb67f1598fd7aa426d1cdfed398fa81e5619075ee5df5aefe46cb7417df0": {
     "sourceId": "9753cb67f1598fd7aa426d1cdfed398fa81e5619075ee5df5aefe46cb7417df0",
     "reproducibleGitChecksum": "c28d23b61a78f989ecfd9a4887e818b4d29c96bdf54783f4c90935843e8c00a4",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm32v7",
-      "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
-      "Directory": "latest/musl/arm32v7",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm32v7",
+        "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
+        "Directory": "latest/musl/arm32v7",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm32v7": {
         "tags": [
@@ -1539,15 +1577,17 @@
   "b81a79eee6c6d37be4b867dad59b9fefbb36e0eedf879cf1c2cf8ea5d05e3124": {
     "sourceId": "b81a79eee6c6d37be4b867dad59b9fefbb36e0eedf879cf1c2cf8ea5d05e3124",
     "reproducibleGitChecksum": "99149604120ea53fce493cd15e2d46dcc4a0c95fca2cc42b80fff27cc7c29033",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm64v8",
-      "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
-      "Directory": "latest/musl/arm64v8",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm64v8",
+        "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
+        "Directory": "latest/musl/arm64v8",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm64v8": {
         "tags": [
@@ -1586,15 +1626,17 @@
   "51e5747cd366107e1a7cca46a2e099925813974ce63b9078d9626b50b48fae5e": {
     "sourceId": "51e5747cd366107e1a7cca46a2e099925813974ce63b9078d9626b50b48fae5e",
     "reproducibleGitChecksum": "6e88131ed46179b9091c6d411dcf1cd97908ccab721106885823a24c40d09841",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-i386",
-      "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
-      "Directory": "latest/musl/i386",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-i386",
+        "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
+        "Directory": "latest/musl/i386",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "i386": {
         "tags": [
@@ -1632,15 +1674,17 @@
   "28ef7af06435ce6e9bd92c7fb07fa1930ef08299aea37b9b71875a6c71d2a5e0": {
     "sourceId": "28ef7af06435ce6e9bd92c7fb07fa1930ef08299aea37b9b71875a6c71d2a5e0",
     "reproducibleGitChecksum": "0edf4a03cf0abab4dc3ddb643ea2557011441c94756fcb4219fd0accdbd15087",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-ppc64le",
-      "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
-      "Directory": "latest/musl/ppc64le",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-ppc64le",
+        "GitCommit": "97dad737e59de0698f74b81a7dac4ce4d834e36c",
+        "Directory": "latest/musl/ppc64le",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "ppc64le": {
         "tags": [
@@ -1678,15 +1722,17 @@
   "23d7aabdd6ac37efd6230bb6e3d07d0b0019a90f71915ec053e2cbec8647939f": {
     "sourceId": "23d7aabdd6ac37efd6230bb6e3d07d0b0019a90f71915ec053e2cbec8647939f",
     "reproducibleGitChecksum": "184229820dec5f0ec79b8dff338a57b5753b86d0deb662c77dc4b4e1a4e191d2",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-riscv64",
-      "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
-      "Directory": "latest/musl/riscv64",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-riscv64",
+        "GitCommit": "10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa",
+        "Directory": "latest/musl/riscv64",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "riscv64": {
         "tags": [
@@ -1724,15 +1770,17 @@
   "937ba89cafe61fe48b4e7b167307a40a5060630417cc5bbb35f2557aae5e6de4": {
     "sourceId": "937ba89cafe61fe48b4e7b167307a40a5060630417cc5bbb35f2557aae5e6de4",
     "reproducibleGitChecksum": "f1eec923f99f36025636a3c1ae130aedfed7779c3764e20ff863d2cc6d04ac07",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-s390x",
-      "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
-      "Directory": "latest/musl/s390x",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-s390x",
+        "GitCommit": "ecf31f814875084a2bc85a162b78f512ea2df0c9",
+        "Directory": "latest/musl/s390x",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "s390x": {
         "tags": [
@@ -1770,15 +1818,17 @@
   "6a18227ecb1f42bd4755b0843ab3d0752a23b193efb5e9a969b0760ddd19cf8a": {
     "sourceId": "6a18227ecb1f42bd4755b0843ab3d0752a23b193efb5e9a969b0760ddd19cf8a",
     "reproducibleGitChecksum": "27d63f8ad18605a011ba51ad8d751137ced48cda3bf7b0d57d0b703a5a758d1b",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-amd64",
-      "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
-      "Directory": "latest/uclibc/amd64",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-amd64",
+        "GitCommit": "d0b7d566eb4f1fa9933984e6fc04ab11f08f4592",
+        "Directory": "latest/uclibc/amd64",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -1816,15 +1866,17 @@
   "db872cd091599cf2e7122035b6695f91e0da175083da118d84ed3fad9fac5714": {
     "sourceId": "db872cd091599cf2e7122035b6695f91e0da175083da118d84ed3fad9fac5714",
     "reproducibleGitChecksum": "53b36cefd44161ae6ac336e26d895b7de646814e3e09d05554e91d982740f744",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm32v5",
-      "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
-      "Directory": "latest/uclibc/arm32v5",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm32v5",
+        "GitCommit": "7044abc7ee26712d998311b402b975124786e0cf",
+        "Directory": "latest/uclibc/arm32v5",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm32v5": {
         "tags": [
@@ -1863,15 +1915,17 @@
   "1ca52688d8766979871c1959cb49752aea3b61f526e94155bec9c2781eacdf11": {
     "sourceId": "1ca52688d8766979871c1959cb49752aea3b61f526e94155bec9c2781eacdf11",
     "reproducibleGitChecksum": "ece85a849af3c4b2468de15350257970aa7bd36e23607a0aab3f58b4d6e6e659",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm32v7",
-      "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
-      "Directory": "latest/uclibc/arm32v7",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm32v7",
+        "GitCommit": "185a3f7f21c307b15ef99b7088b228f004ff5f11",
+        "Directory": "latest/uclibc/arm32v7",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm32v7": {
         "tags": [
@@ -1910,15 +1964,17 @@
   "3987c80147f7aef388ae723a6bce970fa724a17b3cb74a2e4f4a058204caa7d0": {
     "sourceId": "3987c80147f7aef388ae723a6bce970fa724a17b3cb74a2e4f4a058204caa7d0",
     "reproducibleGitChecksum": "a9ff0eba05d9c907b2fdf3bbc9eb397e67dcc0944063cbfae5be30b60440f116",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-arm64v8",
-      "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
-      "Directory": "latest/uclibc/arm64v8",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-arm64v8",
+        "GitCommit": "a8344687869ba9f95e140a62a915a30822ff2147",
+        "Directory": "latest/uclibc/arm64v8",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "arm64v8": {
         "tags": [
@@ -1957,15 +2013,17 @@
   "5d3c7f5271e2c2f8c25fd7583e20946c9756be806d554837f4aff3247438cdc6": {
     "sourceId": "5d3c7f5271e2c2f8c25fd7583e20946c9756be806d554837f4aff3247438cdc6",
     "reproducibleGitChecksum": "882db5aa14620ea7decded765d64f05700feb25b1770a5a4817e4d8e08fec920",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-i386",
-      "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
-      "Directory": "latest/uclibc/i386",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-i386",
+        "GitCommit": "64e761e756e3281bc9a49235ee200dfc1f5a525e",
+        "Directory": "latest/uclibc/i386",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "i386": {
         "tags": [
@@ -2003,15 +2061,17 @@
   "b0bb94feb28087aee21e4a4c0b9cd51b0ba4737c166033e34fa245433b0f7447": {
     "sourceId": "b0bb94feb28087aee21e4a4c0b9cd51b0ba4737c166033e34fa245433b0f7447",
     "reproducibleGitChecksum": "acfeadf772789a80427f642691efcb0daeeabe73ce4753318f25760c3ead6e18",
-    "entry": {
-      "GitRepo": "https://github.com/docker-library/busybox.git",
-      "GitFetch": "refs/heads/dist-mips64le",
-      "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
-      "Directory": "latest/uclibc/mips64le",
-      "File": "index.json",
-      "Builder": "oci-import",
-      "SOURCE_DATE_EPOCH": 1709081058
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/docker-library/busybox.git",
+        "GitFetch": "refs/heads/dist-mips64le",
+        "GitCommit": "ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3",
+        "Directory": "latest/uclibc/mips64le",
+        "File": "index.json",
+        "Builder": "oci-import",
+        "SOURCE_DATE_EPOCH": 1709081058
+      }
+    ],
     "arches": {
       "mips64le": {
         "tags": [
@@ -2049,15 +2109,17 @@
   "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62": {
     "sourceId": "248a27866206a7cffd2764f528bf60c98d80e22d8855e3e47b5ba997b0270a62",
     "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-    "entry": {
-      "GitRepo": "https://github.com/tianon/dockerfiles.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-      "Directory": "infosiftr-moby",
-      "File": "Dockerfile",
-      "Builder": "",
-      "SOURCE_DATE_EPOCH": 1709705469
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/tianon/dockerfiles.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+        "Directory": "infosiftr-moby",
+        "File": "Dockerfile",
+        "Builder": "",
+        "SOURCE_DATE_EPOCH": 1709705469
+      }
+    ],
     "arches": {
       "amd64": {
         "tags": [
@@ -2267,15 +2329,17 @@
   "e141d79c2a22ece4486416cbea97b88bf7595236e866e396d42353cb0d3e1633": {
     "sourceId": "e141d79c2a22ece4486416cbea97b88bf7595236e866e396d42353cb0d3e1633",
     "reproducibleGitChecksum": "739b58d3d99cf37800d665f9b11772182af81f3501e7f6ad143f74ffa202b32b",
-    "entry": {
-      "GitRepo": "https://github.com/tianon/dockerfiles.git",
-      "GitFetch": "refs/heads/master",
-      "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
-      "Directory": "infosiftr-moby",
-      "File": "Dockerfile.unstable",
-      "Builder": "",
-      "SOURCE_DATE_EPOCH": 1709705469
-    },
+    "entries": [
+      {
+        "GitRepo": "https://github.com/tianon/dockerfiles.git",
+        "GitFetch": "refs/heads/master",
+        "GitCommit": "37f1b58c0dc59e6589a0f55849f73d6ef0988cd8",
+        "Directory": "infosiftr-moby",
+        "File": "Dockerfile.unstable",
+        "Builder": "",
+        "SOURCE_DATE_EPOCH": 1709705469
+      }
+    ],
     "arches": {
       "riscv64": {
         "tags": [


### PR DESCRIPTION
When we normalize sources by deduplicating on `sourceId`, we end up losing a little bit of data that's important for being able to reconnect `source` objects with their lines in `library/foo`.

This resolves that by adjusting our `entry` object to be a vector of `entries` instead, but sorted using the same `SOURCE_DATE_EPOCH` tiebreaker we used previously so that `.entries[0]` is the same as our old `.entry`, but we keep the full list of values for later use/lookup/cross-referencing.

I have additionally verified that `meta.jq` here was the only place we are actively consuming from the `.entry` object (currently), so this should be fully sufficient (no changes necessary elsewhere).