### PR TITLE
Improve triggers to be based on source changes instead of meta job running

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -4,8 +4,8 @@ properties([
 	disableResume(),
 	durabilityHint('PERFORMANCE_OPTIMIZED'),
 	pipelineTriggers([
-		upstream('../meta'),
-		cron('H H/6 * * *'), // run every few hours whether we "need" it or not
+		githubPush(),
+		cron('@daily'), // check periodically, just in case
 	]),
 ])
 

--- a/Jenkinsfile.trigger
+++ b/Jenkinsfile.trigger
@@ -4,7 +4,8 @@ properties([
 	disableResume(),
 	durabilityHint('PERFORMANCE_OPTIMIZED'),
 	pipelineTriggers([
-		upstream(threshold: 'UNSTABLE', upstreamProjects: '../meta'),
+		githubPush(),
+		cron('@hourly'), // run hourly whether we "need" it or not
 	]),
 ])
 


### PR DESCRIPTION
Follow up to https://github.com/docker-library/meta-scripts/pull/116 to improve job trigger accuracy (with some time based fallbacks).