### PR TITLE
Always setup buildkit

### DIFF
--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -123,16 +123,14 @@ node('multiarch-' + env.BASHBREW_ARCH) { ansiColor('xterm') {
 
 			def buildEnvs = []
 			stage('Prep') {
-				if (obj.commands.build.contains(' buildx ')) {
-					def json = sh(returnStdout: true, script: '''#!/usr/bin/env bash
-						set -Eeuo pipefail -x
+				def json = sh(returnStdout: true, script: '''#!/usr/bin/env bash
+					set -Eeuo pipefail -x
 
-						.doi/.bin/bashbrew-buildkit-env-setup.sh \\
-							| jq 'to_entries | map(.key + "=" + .value)'
-					''').trim()
-					if (json) {
-						buildEnvs += readJSON(text: json)
-					}
+					.doi/.bin/bashbrew-buildkit-env-setup.sh \\
+						| jq 'to_entries | map(.key + "=" + .value)'
+				''').trim()
+				if (json) {
+					buildEnvs += readJSON(text: json)
 				}
 			}
 


### PR DESCRIPTION
This is technically a follow-up to #124 (which assumes variables set by this are set, but they aren't because there's no `buildx` in our command anymore).