### PR TITLE
Move windows builds to auto scaling groups

### DIFF
--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -12,6 +12,7 @@ properties([
 	parameters([
 		string(name: 'buildId', trim: true),
 		string(name: 'identifier', trim: true, description: '(optional) used to set <code>currentBuild.displayName</code> to a meaningful value earlier'),
+		string(name: 'windowsVersion', trim: true, description: '(optional) used to select the Windows node (2025, 2022, etc)'),
 	]),
 ])
 
@@ -21,7 +22,15 @@ if (params.identifier) {
 	currentBuild.displayName = params.identifier + ' (#' + currentBuild.number + ')'
 }
 
-node('multiarch-' + env.BASHBREW_ARCH) { ansiColor('xterm') {
+def nodeExpression = 'multiarch-' + env.BASHBREW_ARCH
+if (params.windowsVersion) {
+	nodeExpression += ' && windows-' + params.windowsVersion
+}
+if (env.BASHBREW_ARCH.startsWith('windows-') && ! params.windowsVersion) {
+	error(env.BASHBREW_ARCH + ' specified, but no Windows OS version (like 2025)')
+}
+
+node(nodeExpression) { ansiColor('xterm') {
 	stage('Checkout') {
 		checkout(scmGit(
 			userRemoteConfigs: [[

--- a/Jenkinsfile.trigger
+++ b/Jenkinsfile.trigger
@@ -176,6 +176,7 @@ stage('trigger') {
 					parameters: [
 						string(name: 'buildId', value: buildObj.buildId),
 						string(name: 'identifier', value: buildObj.identifier),
+						string(name: 'windowsVersion', value: buildObj.windowsVersion),
 					],
 					propagate: false,
 					// trigger these quickly so they all get added to Jenkins queue in "queue" order (also using "waitForStart" means we have to wait for the entire "quietPeriod" before we get to move on and schedule more)


### PR DESCRIPTION
Now that we have auto scaling groups, let's move more off of GHA. Since we don't have virtualization extensions, the build job needs the Window OS version to select the right node labels so that the correct autoscaling group is used (OS version must match or it can't run/build the Docker image).

One of the benefits is that with our Trigger jobs, we can actively wait on the queue of Build jobs in Jenkins instead of the "throw it over the wall" of GHA.

We'll also need to enable the [Windows build job](https://doi-janky.infosiftr.net/job/meta/job/windows-amd64/job/build/) after merging.