### PR TITLE
Move meta job to its dedicated ASG instance

### DIFF
--- a/Jenkinsfile.meta
+++ b/Jenkinsfile.meta
@@ -8,7 +8,7 @@ properties([
 	]),
 ])
 
-node {
+node('doi-meta') { // use the dedicated meta instance
 	stage('Checkout') {
 		// prevent meta from triggering itself
 		// If 'Include in polling' is enabled or 'Include in changelog' is enabled, then when polling occurs, the job will be started if changes are detected from this SCM source.


### PR DESCRIPTION
This moves the meta job to our auto scaling groups, but to a group of one dedicated to just the meta job. We are using an ASG so that it can be scaled to none when meta isn't running.