### PR TITLE
Make `crane` download conditional

### DIFF
--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -58,29 +58,34 @@ node(nodeExpression) { ansiColor('xterm') {
 
 	env.BASHBREW_META_SCRIPTS = env.WORKSPACE + '/meta/.scripts'
 
-	dir('.bin') {
-		deleteDir()
+	if (sh(
+		script: 'crane version',
+		returnStatus: true,
+	) != 0) {
+		dir('.bin') {
+			deleteDir()
 
-		stage('Crane') {
-			sh '''#!/usr/bin/env bash
-				set -Eeuo pipefail -x
+			stage('Crane') {
+				sh '''#!/usr/bin/env bash
+					set -Eeuo pipefail -x
 
-				ext=''
-				if [ "$BASHBREW_ARCH" = 'windows-amd64' ]; then
-					ext='.exe'
-				fi
+					ext=''
+					if [ "$BASHBREW_ARCH" = 'windows-amd64' ]; then
+						ext='.exe'
+					fi
 
-				# https://doi-janky.infosiftr.net/job/wip/job/crane
-				# ipv6 can be extremely slow on s390x so set a timeout and have wget try the other DNS addresses instead
-				wget --timeout=5 -O "crane$ext" "https://doi-janky.infosiftr.net/job/wip/job/crane/lastSuccessfulBuild/artifact/crane-$BASHBREW_ARCH$ext" --progress=dot:giga
-				# TODO checksum verification ("checksums.txt")
-				chmod +x "crane$ext"
-				"./crane$ext" version
-			'''
-			if (env.BASHBREW_ARCH == 'windows-amd64') {
-				env.PATH = "${workspace}/.bin;${env.PATH}"
-			} else {
-				env.PATH = "${workspace}/.bin:${env.PATH}"
+					# https://doi-janky.infosiftr.net/job/wip/job/crane
+					# ipv6 can be extremely slow on s390x so set a timeout and have wget try the other DNS addresses instead
+					wget --timeout=5 -O "crane$ext" "https://doi-janky.infosiftr.net/job/wip/job/crane/lastSuccessfulBuild/artifact/crane-$BASHBREW_ARCH$ext" --progress=dot:giga
+					# TODO checksum verification ("checksums.txt")
+					chmod +x "crane$ext"
+					"./crane$ext" version
+				'''
+				if (env.BASHBREW_ARCH == 'windows-amd64') {
+					env.PATH = "${workspace}/.bin;${env.PATH}"
+				} else {
+					env.PATH = "${workspace}/.bin:${env.PATH}"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Our new systems have `crane` pre-installed, so we don't need to download it on them.