### PR TITLE
Move amd64 and i386 builds to auto scaling groups

### DIFF
--- a/jenkins.jq
+++ b/jenkins.jq
@@ -62,13 +62,8 @@ def get_arch_queue($arch):
 			needs_build
 			and .build.arch == $arch
 		)
-		|  if IN(.build.arch; "amd64", "i386") then
-			# "GHA" architectures (anything we add a "gha_payload" to will be run on GHA in the queue)
-			.gha_payload = (gha_payload | @json)
-		else
-			# add friendly windows os version (2022, 2025)
-			. + windows_version
-		end
+		# add friendly windows os version (2022, 2025)
+		| . + windows_version
 		| .identifier = .source.arches[.build.arch].tags[0]
 	)
 ;


### PR DESCRIPTION
Following https://github.com/docker-library/meta-scripts/pull/130, this moves the Linux `amd64` and `i386` builds to our auto scaling groups as well.

There are now unused functions (like [`gha_payload`](https://github.com/docker-library/meta-scripts/blob/86288421105378da0d6543766e55ede9c5f60cf6/jenkins.jq#L44-L55)) to remove once we no longer want to come back to GHA for building.

We'll also need to enable the [build](https://doi-janky.infosiftr.net/job/meta/job/amd64/job/build/) [jobs](https://doi-janky.infosiftr.net/job/meta/job/i386/job/build/) after merging.